### PR TITLE
Preserve double precision in V3d kd-trees

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,5 @@
+- [Normals] Preserved full double precision in V3d kd-tree construction and reconstruction (#40)
+
 ### 5.6.3
 - Updated SharpCompress to 0.48.1 to address CVE-2026-44788
 

--- a/ai/GEOMETRY.md
+++ b/ai/GEOMETRY.md
@@ -145,6 +145,23 @@ Normal estimation from k-nearest neighbors via PCA.
 | Type | Purpose |
 |------|---------|
 | `Normals` (static) | Extension methods for estimating normals from point clouds |
+| `KdTreeExtensions` (static) | Builds and reconstructs point kd-trees for `V3f` and `V3d` collections |
+
+### Building Point KD-Trees
+
+```csharp
+V3d[] worldPoints = LoadWorldPoints();
+var kdTree = worldPoints.BuildKdTree();
+
+// Reconstruct a tree from persisted topology without reordering the input.
+PointRkdTreeDData data = kdTree.Data;
+var restored = ((IList<V3d>)worldPoints).ToKdTree(data);
+```
+
+All synchronous and asynchronous `V3d` builders, including reconstruction from
+`PointRkdTreeDData`, access coordinates as `double`. This retains distinctions at
+large world-coordinate offsets that a conversion to `float` would lose. `V3f`
+overloads intentionally remain single precision.
 
 ### Usage
 

--- a/src/Aardvark.Algodat.Tests/KdTreeTests.cs
+++ b/src/Aardvark.Algodat.Tests/KdTreeTests.cs
@@ -12,6 +12,8 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using Aardvark.Base;
 using Aardvark.Geometry.Points;
 using NUnit.Framework;
@@ -36,6 +38,72 @@ namespace Aardvark.Geometry.Tests
             {
                 ClassicAssert.IsTrue(ps[i] == copy[i]);
             }
+        }
+
+        [Test]
+        public async Task V3dKdTreeBuildersPreservePrecisionAtLargeOffsets()
+        {
+            var result = await AssertV3dKdTreesMatchBruteForce(new V3d(1_000_000_000.0));
+            Assert.That(result.Index, Is.Zero);
+            Assert.That(result.Distance, Is.EqualTo(Math.Sqrt(6144.0)).Within(1e-12));
+        }
+
+        [Test]
+        public async Task V3dKdTreeBuildersMatchOrdinaryCoordinateResults()
+        {
+            var ordinary = await AssertV3dKdTreesMatchBruteForce(V3d.Zero);
+            var shifted = await AssertV3dKdTreesMatchBruteForce(new V3d(1_000_000_000.0));
+
+            Assert.That(shifted.Index, Is.EqualTo(ordinary.Index));
+            Assert.That(shifted.Distance, Is.EqualTo(ordinary.Distance).Within(1e-12));
+        }
+
+        private static async Task<(long Index, double Distance)> AssertV3dKdTreesMatchBruteForce(V3d offset)
+        {
+            var points = new[]
+            {
+                offset + new V3d(96, 64, -96),
+                offset + new V3d(96, -32, -96),
+                offset + new V3d(32, 96, 128)
+            };
+            var query = offset + new V3d(128, 32, -32);
+            var arrayCopy = (V3d[])points.Clone();
+            IList<V3d> list = new List<V3d>(points);
+            var listCopy = new List<V3d>(list);
+
+            long expectedIndex = 0;
+            var expectedDistance = Vec.Distance(query, points[0]);
+            for (var i = 1; i < points.Length; i++)
+            {
+                var distance = Vec.Distance(query, points[i]);
+                if (distance < expectedDistance)
+                {
+                    expectedIndex = i;
+                    expectedDistance = distance;
+                }
+            }
+
+            var validData = points.CreateRkdTreeDist2(1e-12).Data;
+            var trees = new[]
+            {
+                points.BuildKdTree(),
+                list.BuildKdTree(),
+                await points.BuildKdTreeAsync(),
+                await list.BuildKdTreeAsync(),
+                points.ToKdTree(validData),
+                list.ToKdTree(validData)
+            };
+
+            foreach (var tree in trees)
+            {
+                var nearest = tree.GetClosest(query);
+                Assert.That(nearest.Index, Is.EqualTo(expectedIndex));
+                Assert.That(nearest.Dist, Is.EqualTo(expectedDistance).Within(1e-12));
+            }
+
+            CollectionAssert.AreEqual(arrayCopy, points);
+            CollectionAssert.AreEqual(listCopy, list);
+            return (expectedIndex, expectedDistance);
         }
     }
 }

--- a/src/Aardvark.Geometry.Normals/KdTreeExtensions.cs
+++ b/src/Aardvark.Geometry.Normals/KdTreeExtensions.cs
@@ -52,6 +52,7 @@ namespace Aardvark.Geometry
 
         /// <summary>
         /// Constructs rkd-tree from points and kd-tree data.
+        /// V3d coordinates retain their full double precision.
         /// </summary>
         public static PointRkdTreeD<V3d[], V3d> ToKdTree(this V3d[] points, PointRkdTreeDData data)
             => new PointRkdTreeD<V3d[], V3d>(
@@ -64,11 +65,12 @@ namespace Aardvark.Geometry
 
         /// <summary>
         /// Constructs rkd-tree from points and kd-tree data.
+        /// V3d coordinates retain their full double precision.
         /// </summary>
         public static PointRkdTreeD<V3d[], V3d> ToKdTree(this IList<V3d> points, PointRkdTreeDData data)
             => new PointRkdTreeD<V3d[], V3d>(
                     3, points.Count, (points is V3d[] ps) ? ps : ((points is List<V3d> ps2) ? ps2.ToArray() : points.ToArray(points.Count)),
-                    (xs, i) => xs[(int)i], (v, i) => (float)v[i],
+                    (xs, i) => xs[(int)i], (v, i) => v[i],
                     (a, b) => Vec.Distance(a, b), (i, a, b) => b - a,
                     (a, b, c) => Vec.DistanceToLine(a, b, c), Fun.Lerp, 1e-12,
                     data
@@ -110,6 +112,7 @@ namespace Aardvark.Geometry
 
         /// <summary>
         /// Computes rkd-tree from given points.
+        /// V3d coordinates retain their full double precision.
         /// </summary>
         public static PointRkdTreeD<V3d[], V3d> BuildKdTree(this V3d[] points, double kdTreeEps = 1e-12)
         {
@@ -117,7 +120,7 @@ namespace Aardvark.Geometry
             if (points.Length == 0) return points.ToKdTree(new PointRkdTreeDData());
             return new PointRkdTreeD<V3d[], V3d>(
                 3, points.Length, points,
-                (xs, i) => xs[(int)i], (v, i) => (float)v[i],
+                (xs, i) => xs[(int)i], (v, i) => v[i],
                 (a, b) => Vec.Distance(a, b), (i, a, b) => b - a,
                 (a, b, c) => Vec.DistanceToLine(a, b, c), Fun.Lerp, kdTreeEps
                 );
@@ -125,6 +128,7 @@ namespace Aardvark.Geometry
 
         /// <summary>
         /// Computes rkd-tree from given points.
+        /// V3d coordinates retain their full double precision.
         /// </summary>
         public static PointRkdTreeD<V3d[], V3d> BuildKdTree(this IList<V3d> points, double kdTreeEps = 1e-12)
         {
@@ -132,7 +136,7 @@ namespace Aardvark.Geometry
             if (points.Count == 0) return points.ToKdTree(new PointRkdTreeDData());
             return new PointRkdTreeD<V3d[], V3d>(
                 3, points.Count, (points is V3d[] ps) ? ps : ((points is List<V3d> ps2) ? ps2.ToArray() : points.ToArray(points.Count)),
-                (xs, i) => xs[(int)i], (v, i) => (float)v[i],
+                (xs, i) => xs[(int)i], (v, i) => v[i],
                 (a, b) => Vec.Distance(a, b), (i, a, b) => b - a,
                 (a, b, c) => Vec.DistanceToLine(a, b, c), Fun.Lerp, kdTreeEps
                 );
@@ -175,6 +179,7 @@ namespace Aardvark.Geometry
 
         /// <summary>
         /// Computes rkd-tree from given points.
+        /// V3d coordinates retain their full double precision.
         /// </summary>
         public static async Task<PointRkdTreeD<V3d[], V3d>> BuildKdTreeAsync(this V3d[] points, double kdTreeEps = 1e-12)
         {
@@ -185,6 +190,7 @@ namespace Aardvark.Geometry
 
         /// <summary>
         /// Computes rkd-tree from given points.
+        /// V3d coordinates retain their full double precision.
         /// </summary>
         public static async Task<PointRkdTreeD<V3d[], V3d>> BuildKdTreeAsync(this IList<V3d> points, float kdTreeEps = 1e-6f)
         {


### PR DESCRIPTION
Fixes #40.

## Summary

- Preserve full `double` coordinates in `V3d` array and `IList` kd-tree builders and in `IList<V3d>` reconstruction from `PointRkdTreeDData`.
- Cover synchronous, asynchronous, and reconstructed trees at ordinary and `1e9`-shifted coordinates with deterministic brute-force regressions, including input-order preservation.
- Document the precision guarantee without changing public signatures, defaults, serialized data, generated sources, or intentional `V3f` behavior.

## Performance

Repeated warmed Release measurements used the same deterministic 32³ point set and 1,024 nearest queries on the parent and corrected revisions:

- Ordinary construction: 17.92 ms → 15.25 ms; allocations unchanged at 4,391,232 B/op.
- Ordinary nearest query: 1,437 ns → 1,357 ns; allocations unchanged at 0 B/op.
- `1e9`-shifted nearest query: 72.9 µs → 0.610 µs, approximately 120× faster.

The old shifted construction appeared faster only because float narrowing collapsed coordinate distinctions and produced different invalid topology. The corrected shifted topology matches the ordinary-coordinate tree.

## Validation

- Focused regressions pass in Debug and Release.
- Complete Release suite: 444 passed, 2 existing skips, 0 failed.
- Complete Release build: 0 warnings, 0 errors.
- Independent review found no blocking issues.
