### PR TITLE
Fix finite line-segment point queries

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,5 @@
+- [PointSet] fixed finite line-segment queries for temporary and kd-tree-free nodes (#42)
+
 ### 5.6.3
 - Updated SharpCompress to 0.48.1 to address CVE-2026-44788
 

--- a/ai/POINT_CLOUDS.md
+++ b/ai/POINT_CLOUDS.md
@@ -116,6 +116,25 @@ if (node.HasKdTree)
 }
 ```
 
+### Querying Near a Finite Line Segment
+
+```csharp
+var segment = new Line3d(start, end);
+foreach (var chunk in pointSet.QueryPointsNearLineSegment(segment, 0.05))
+{
+    Process(chunk.Positions, chunk.Colors, chunk.PartIndices);
+}
+```
+
+The query returns every point within the requested distance of the finite
+segment; it has no implicit result-count limit. Points collinear with the
+segment but beyond either endpoint are tested against the nearest endpoint.
+Leaf nodes use their kd-tree when available and otherwise scan local positions,
+so temporary import nodes are supported transparently. The `Custom` overload
+uses the same candidate selection and returns requested per-point arrays in a
+`GenericChunk`. When `minCellExponent` makes a node terminal, a node without
+stored positions yields no chunk.
+
 ### Working with Chunks (Streaming Import)
 
 ```csharp

--- a/src/Aardvark.Algodat.Tests/QueryTests.cs
+++ b/src/Aardvark.Algodat.Tests/QueryTests.cs
@@ -12,6 +12,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 using Aardvark.Base;
+using Aardvark.Data;
 using Aardvark.Data.Points;
 using Aardvark.Geometry.Points;
 using NUnit.Framework;
@@ -80,6 +81,250 @@ namespace Aardvark.Geometry.Tests
         }
 
         #region Ray3d, Line3d
+
+        private static readonly Line3d LineSegmentQuery = new(
+            new V3d(0.25, 0.5, 0.5),
+            new V3d(0.75, 0.5, 0.5)
+            );
+
+        private const double LineSegmentQueryRadius = 0.04;
+
+        private static readonly Durable.Def LineSegmentCustomAttribute = new(
+            new Guid("5813c587-d8ab-4b40-a0e9-11887818ed61"),
+            "Tests.LineSegmentCustomAttribute",
+            "Per-point values used to verify line-segment custom queries.",
+            Durable.Primitives.Int32Array.Id,
+            isArray: true
+            );
+
+        private static readonly Durable.Def LineSegmentUnrequestedAttribute = new(
+            new Guid("01d7ec80-4cab-4940-91da-e60f9590e4f1"),
+            "Tests.LineSegmentUnrequestedAttribute",
+            "Per-point values that line-segment custom queries must omit unless requested.",
+            Durable.Primitives.Int32Array.Id,
+            isArray: true
+            );
+
+        private static (
+            V3d[] Positions,
+            C4b[] Colors,
+            V3f[] Normals,
+            int[] Intensities,
+            byte[] Classifications,
+            int[] PartIndices
+            ) CreateLineSegmentQueryData()
+        {
+            var positions = new[]
+            {
+                new V3d(0.1250, 0.500000, 0.5), // beyond P0
+                new V3d(0.5000, 0.468750, 0.5), // selected
+                new V3d(0.5000, 0.625000, 0.5), // too far from the segment
+                new V3d(0.3125, 0.515625, 0.5), // selected
+                new V3d(0.8750, 0.500000, 0.5), // beyond P1
+                new V3d(0.6875, 0.500000, 0.5), // selected
+            };
+            var colors = new C4b[positions.Length];
+            var normals = new V3f[positions.Length];
+            var intensities = new int[positions.Length];
+            var classifications = new byte[positions.Length];
+            var partIndices = new int[positions.Length];
+            for (var i = 0; i < positions.Length; i++)
+            {
+                colors[i] = new C4b((byte)(10 + i), (byte)(20 + i), (byte)(30 + i), (byte)255);
+                normals[i] = new V3f(i + 1, i + 2, i + 3);
+                intensities[i] = 100 + i;
+                classifications[i] = (byte)(40 + i);
+                partIndices[i] = 200 + i;
+            }
+            return (positions, colors, normals, intensities, classifications, partIndices);
+        }
+
+        private static PointSetNode CreateLineSegmentQueryNode(bool temporary, object partIndices, int splitLimit)
+        {
+            var data = CreateLineSegmentQueryData();
+            var storage = PointCloud.CreateInMemoryStore(cache: default);
+            return InMemoryPointSet.Build(
+                data.Positions,
+                data.Colors,
+                data.Normals,
+                data.Intensities,
+                data.Classifications,
+                partIndices,
+                Cell.Unit,
+                splitLimit
+                ).ToPointSetNode(storage, isTemporaryImportNode: temporary);
+        }
+
+        private static (
+            V3d Position,
+            C4b Color,
+            V3f Normal,
+            int Intensity,
+            byte Classification,
+            int PartIndex
+            )[] GetLineSegmentQueryRows(IEnumerable<Chunk> chunks)
+        {
+            var result = new List<(V3d, C4b, V3f, int, byte, int)>();
+            foreach (var chunk in chunks)
+            {
+                for (var i = 0; i < chunk.Count; i++)
+                {
+                    result.Add((
+                        chunk.Positions[i],
+                        chunk.Colors![i],
+                        chunk.Normals![i],
+                        chunk.Intensities![i],
+                        chunk.Classifications![i],
+                        PartIndexUtils.Get(chunk.PartIndices, i) ?? -1
+                        ));
+                }
+            }
+            result.Sort((a, b) => a.Item1.X.CompareTo(b.Item1.X));
+            return result.ToArray();
+        }
+
+        [Test]
+        public void QueryPointsNearLineSegmentTraversesTemporaryTreesAndPreservesAttributes()
+        {
+            var data = CreateLineSegmentQueryData();
+            var root = CreateLineSegmentQueryNode(temporary: true, data.PartIndices, splitLimit: 1);
+
+            Assert.That(root.IsLeaf, Is.False);
+            Assert.That(root.HasPositions, Is.False);
+            Assert.That(root.EnumerateNodes().Where(x => x.IsLeaf), Has.All.Matches<IPointCloudNode>(x => !x.HasKdTree));
+
+            var chunks = root.QueryPointsNearLineSegment(LineSegmentQuery, LineSegmentQueryRadius).ToArray();
+            var actual = GetLineSegmentQueryRows(chunks);
+            var expectedIndices = new[] { 3, 1, 5 };
+
+            Assert.That(chunks, Has.Length.GreaterThan(1), "Enumeration must continue after the first matching node.");
+            Assert.That(actual, Has.Length.EqualTo(expectedIndices.Length));
+            for (var i = 0; i < expectedIndices.Length; i++)
+            {
+                var index = expectedIndices[i];
+                Assert.That(actual[i].Position, Is.EqualTo(data.Positions[index]));
+                Assert.That(actual[i].Color, Is.EqualTo(data.Colors[index]));
+                Assert.That(actual[i].Normal, Is.EqualTo(data.Normals[index]));
+                Assert.That(actual[i].Intensity, Is.EqualTo(data.Intensities[index]));
+                Assert.That(actual[i].Classification, Is.EqualTo(data.Classifications[index]));
+                Assert.That(actual[i].PartIndex, Is.EqualTo(data.PartIndices[index]));
+                Assert.That(LineSegmentQuery.GetMinimalDistanceTo(actual[i].Position), Is.LessThanOrEqualTo(LineSegmentQueryRadius));
+            }
+
+            Assert.That(actual.Select(x => x.Position), Does.Not.Contain(data.Positions[0]));
+            Assert.That(actual.Select(x => x.Position), Does.Not.Contain(data.Positions[4]));
+            Assert.That(
+                root.QueryPointsNearLineSegment(LineSegmentQuery, LineSegmentQueryRadius, root.Cell.Exponent),
+                Is.Empty,
+                "A positionless node made terminal by minCellExponent must not fabricate results."
+                );
+
+            var scalarRoot = CreateLineSegmentQueryNode(temporary: true, partIndices: 17, splitLimit: 1);
+            var scalarChunks = scalarRoot.QueryPointsNearLineSegment(LineSegmentQuery, LineSegmentQueryRadius).ToArray();
+            Assert.That(scalarChunks.Sum(x => x.Count), Is.EqualTo(expectedIndices.Length));
+            Assert.That(scalarChunks, Has.All.Matches<Chunk>(x => x.PartIndices is int value && value == 17));
+        }
+
+        [Test]
+        public void QueryPointsNearLineSegmentMatchesKdTreeAndBruteForce()
+        {
+            var kdTreeRoot = CreateLineSegmentQueryNode(temporary: false, partIndices: null, splitLimit: 1);
+            var bruteForceRoot = CreateLineSegmentQueryNode(temporary: true, partIndices: null, splitLimit: 1);
+
+            Assert.That(kdTreeRoot.EnumerateNodes().Where(x => x.IsLeaf), Has.All.Matches<IPointCloudNode>(x => x.HasKdTree));
+            Assert.That(bruteForceRoot.EnumerateNodes().Where(x => x.IsLeaf), Has.All.Matches<IPointCloudNode>(x => !x.HasKdTree));
+
+            var kdTreeRows = GetLineSegmentQueryRows(kdTreeRoot.QueryPointsNearLineSegment(LineSegmentQuery, LineSegmentQueryRadius));
+            var bruteForceRows = GetLineSegmentQueryRows(bruteForceRoot.QueryPointsNearLineSegment(LineSegmentQuery, LineSegmentQueryRadius));
+            Assert.That(bruteForceRows, Is.EqualTo(kdTreeRows));
+        }
+
+        [Test]
+        public void QueryPointsNearLineSegmentCustomSubsetsAttributesWithoutKdTree()
+        {
+            var data = CreateLineSegmentQueryData();
+            var customValues = Enumerable.Range(1000, data.Positions.Length).ToArray();
+            var unrequestedValues = Enumerable.Range(2000, data.Positions.Length).ToArray();
+
+            IPointCloudNode AddCustomAttributes(IPointCloudNode node)
+            {
+                if (node.IsLeaf)
+                {
+                    var positions = node.PositionsAbsolute;
+                    var selectedCustomValues = new int[positions.Length];
+                    var selectedUnrequestedValues = new int[positions.Length];
+                    for (var i = 0; i < positions.Length; i++)
+                    {
+                        var originalIndex = Array.IndexOf(data.Positions, positions[i]);
+                        Assert.That(originalIndex, Is.GreaterThanOrEqualTo(0));
+                        selectedCustomValues[i] = customValues[originalIndex];
+                        selectedUnrequestedValues[i] = unrequestedValues[originalIndex];
+                    }
+                    return node.With(new Dictionary<Durable.Def, object>
+                    {
+                        [LineSegmentCustomAttribute] = selectedCustomValues,
+                        [LineSegmentUnrequestedAttribute] = selectedUnrequestedValues,
+                    }).WriteToStore();
+                }
+
+                var subnodes = new IPointCloudNode[8];
+                for (var i = 0; i < subnodes.Length; i++)
+                {
+                    var child = node.Subnodes![i];
+                    if (child != null) subnodes[i] = AddCustomAttributes(child.Value);
+                }
+                return node.WithSubNodes(subnodes);
+            }
+
+            var root = AddCustomAttributes(
+                CreateLineSegmentQueryNode(temporary: true, data.PartIndices, splitLimit: 1)
+                );
+
+            Assert.That(root.IsLeaf, Is.False);
+            Assert.That(root.HasPositions, Is.False);
+            Assert.That(root.HasBoundingBoxExactLocal, Is.False);
+            Assert.That(root.HasKdTree, Is.False);
+
+            var chunks = root.QueryPointsNearLineSegmentCustom(
+                LineSegmentQuery,
+                LineSegmentQueryRadius,
+                LineSegmentCustomAttribute
+                ).ToArray();
+            var actual = new List<(V3d Position, int Value)>();
+            foreach (var chunk in chunks)
+            {
+                Assert.That(chunk.Data.ContainsKey(LineSegmentUnrequestedAttribute), Is.False);
+                var positions = chunk.PositionsAsV3d;
+                var values = (int[])chunk.Data[LineSegmentCustomAttribute];
+                for (var i = 0; i < chunk.Count; i++) actual.Add((positions[i], values[i]));
+            }
+            actual.Sort((a, b) => a.Position.X.CompareTo(b.Position.X));
+
+            var expectedIndices = new[] { 3, 1, 5 };
+            Assert.That(actual, Has.Count.EqualTo(expectedIndices.Length));
+            for (var i = 0; i < expectedIndices.Length; i++)
+            {
+                var index = expectedIndices[i];
+                Assert.That(actual[i].Position, Is.EqualTo(data.Positions[index]));
+                Assert.That(actual[i].Value, Is.EqualTo(customValues[index]));
+            }
+
+            var standardPositions = root
+                .QueryPointsNearLineSegment(LineSegmentQuery, LineSegmentQueryRadius)
+                .SelectMany(x => x.Positions)
+                .OrderBy(x => x.X)
+                .ToArray();
+            Assert.That(actual.Select(x => x.Position), Is.EqualTo(standardPositions));
+            Assert.That(
+                root.QueryPointsNearLineSegmentCustom(
+                    LineSegmentQuery,
+                    LineSegmentQueryRadius,
+                    root.Cell.Exponent,
+                    LineSegmentCustomAttribute
+                    ).Sum(x => x.Count),
+                Is.Zero
+                );
+        }
 
         [Test]
         public void CanQueryPointsAlongRay()

--- a/src/Aardvark.Geometry.PointSet/Queries/QueriesRayLine3d.cs
+++ b/src/Aardvark.Geometry.PointSet/Queries/QueriesRayLine3d.cs
@@ -68,7 +68,7 @@ public static partial class Queries
     }
 
     /// <summary>
-    /// Points within given distance of a line segment (at most 1000).
+    /// Enumerates chunks containing points within the given distance of a finite line segment.
     /// </summary>
     public static IEnumerable<Chunk> QueryPointsNearLineSegment(
         this PointSet self, Line3d lineSegment, double maxDistanceToRay, int minCellExponent = int.MinValue
@@ -76,7 +76,7 @@ public static partial class Queries
         => QueryPointsNearLineSegment(self.Root.Value, lineSegment, maxDistanceToRay, minCellExponent);
 
     /// <summary>
-    /// Points within given distance of a line segment (at most 1000).
+    /// Enumerates chunks containing points within the given distance of a finite line segment.
     /// </summary>
     public static IEnumerable<GenericChunk> QueryPointsNearLineSegmentCustom(
         this PointSet self, Line3d lineSegment, double maxDistanceToRay, params Durable.Def[] customAttributes
@@ -84,7 +84,7 @@ public static partial class Queries
         => QueryPointsNearLineSegmentCustom(self, lineSegment, maxDistanceToRay, int.MinValue, customAttributes);
     
     /// <summary>
-    /// Points within given distance of a line segment (at most 1000).
+    /// Enumerates chunks containing points within the given distance of a finite line segment.
     /// </summary>
     public static IEnumerable<GenericChunk> QueryPointsNearLineSegmentCustom(
         this PointSet self, Line3d lineSegment, double maxDistanceToRay, int minCellExponent, params Durable.Def[] customAttributes
@@ -93,83 +93,31 @@ public static partial class Queries
 
 
     /// <summary>
-    /// Points within given distance of a line segment (at most 1000).
+    /// Enumerates chunks containing points within the given distance of a finite line segment.
     /// </summary>
     public static IEnumerable<Chunk> QueryPointsNearLineSegment(
         this IPointCloudNode node, Line3d lineSegment, double maxDistanceToRay, int minCellExponent = int.MinValue
         )
     {
-        if (!node.HasPositions) yield break;
+        var isTerminal = node.IsLeaf || node.Cell.Exponent == minCellExponent;
+        if (isTerminal && !node.HasPositions) yield break;
 
-        var centerGlobal = node.Center;
-        var s0Local = lineSegment.P0 - centerGlobal;
-        var s1Local = lineSegment.P1 - centerGlobal;
-        var rayLocal = new Ray3d(s0Local, (s1Local - s0Local).Normalized);
+        var lineLocal = ToLocalLineSegment(node, lineSegment);
+        if (!MayContainPointsNearLineSegment(node, lineLocal, maxDistanceToRay)) yield break;
 
-        var worstCaseDist = node.BoundingBoxExactLocal.Size3f.Length * 0.5 + maxDistanceToRay;
-        var d0 = rayLocal.GetMinimalDistanceTo((V3d)node.BoundingBoxExactLocal.Center);
-        if (d0 > worstCaseDist) yield break;
-
-        if (node.IsLeaf || node.Cell.Exponent == minCellExponent)
+        if (isTerminal)
         {
-            if (node.HasKdTree)
-            {
-                var indexArray = node.KdTree.Value.GetClosestToLine(
-                    (V3f)s0Local, (V3f)s1Local,
-                    (float)maxDistanceToRay,
-                    node.PointCountCell
-                    );
+            var ia = GetLineSegmentCandidateIndices(node, lineLocal, maxDistanceToRay);
+            if (ia.Count == 0) yield break;
 
-                if (indexArray.Count > 0)
-                {
-                    var ia = indexArray.MapToArray(x => (int)x.Index);
-                    var ps = new V3d[ia.Length];
-                    var cs = node.HasColors ? new C4b[ia.Length] : null;
-                    var ns = node.HasNormals ? new V3f[ia.Length] : null;
-                    var js = node.HasIntensities ? new int[ia.Length] : null;
-                    var ks = node.HasClassifications ? new byte[ia.Length] : null;
-                    var qs = PartIndexUtils.Subset(node.PartIndices, ia);
+            var ps = GetSelectedGlobalPositions(node, ia);
+            var cs = node.Colors?.Value.Subset(ia);
+            var ns = node.Normals?.Value.Subset(ia);
+            var js = node.Intensities?.Value.Subset(ia);
+            var ks = node.Classifications?.Value.Subset(ia);
+            var qs = PartIndexUtils.Subset(node.PartIndices, ia);
 
-                    for (var i = 0; i < ia.Length; i++)
-                    {
-                        var index = ia[i];
-                        ps[i] = centerGlobal + (V3d)node.Positions.Value[index];
-                        if (node.HasColors) cs![i] = node.Colors.Value[index];
-                        if (node.HasNormals) ns![i] = node.Normals.Value[index];
-                        if (node.HasIntensities) js![i] = node.Intensities.Value[index];
-                        if (node.HasClassifications) ks![i] = node.Classifications.Value[index];
-                    }
-                    var chunk = new Chunk(ps, cs, ns, js, ks, qs, partIndexRange: null, bbox: null);
-                    yield return chunk;
-                }
-            }
-            else
-            {
-                // do it without kd-tree ;-)
-                var psLocal = node.Positions.Value;
-
-                var ia = new List<int>();
-                for (var i = 0; i < psLocal.Length; i++)
-                {
-                    var d = rayLocal.GetMinimalDistanceTo((V3d)psLocal[i]);
-                    if (d > maxDistanceToRay) continue;
-                    ia.Add(i);
-                }
-
-                if (ia.Count > 0)
-                {
-                    yield return new Chunk(
-                        node.PositionsAbsolute.Subset(ia),
-                        node.Colors?.Value.Subset(ia),
-                        node.Normals?.Value.Subset(ia),
-                        node.Intensities?.Value.Subset(ia),
-                        node.Classifications?.Value.Subset(ia),
-                        partIndices: PartIndexUtils.Subset(node.PartIndices, ia),
-                        partIndexRange: null,
-                        bbox: null);
-                    throw new NotImplementedException("PARTINDICES");
-                }
-            }
+            yield return new Chunk(ps, cs, ns, js, ks, qs, partIndexRange: null, bbox: null);
         }
         else // inner node
         {
@@ -184,7 +132,7 @@ public static partial class Queries
     }
 
     /// <summary>
-    /// Points within given distance of a line segment (at most 1000).
+    /// Enumerates chunks containing points within the given distance of a finite line segment.
     /// </summary>
     public static IEnumerable<GenericChunk> QueryPointsNearLineSegmentCustom(
         this IPointCloudNode node, Line3d lineSegment, double maxDistanceToRay, params Durable.Def[] customAttributes
@@ -192,52 +140,36 @@ public static partial class Queries
         => QueryPointsNearLineSegmentCustom(node, lineSegment, maxDistanceToRay, int.MinValue, customAttributes);
 
     /// <summary>
-    /// Points within given distance of a line segment (at most 1000).
+    /// Enumerates chunks containing points within the given distance of a finite line segment.
     /// </summary>
     public static IEnumerable<GenericChunk> QueryPointsNearLineSegmentCustom(
         this IPointCloudNode node, Line3d lineSegment, double maxDistanceToRay, int minCellExponent, params Durable.Def[] customAttributes
         )
     {
-        if (!node.HasPositions) yield break;
+        var isTerminal = node.IsLeaf || node.Cell.Exponent == minCellExponent;
+        if (isTerminal && !node.HasPositions) yield break;
 
-        var centerGlobal = node.Center;
-        var s0Local = lineSegment.P0 - centerGlobal;
-        var s1Local = lineSegment.P1 - centerGlobal;
-        var rayLocal = new Ray3d(s0Local, (s1Local - s0Local).Normalized);
+        var lineLocal = ToLocalLineSegment(node, lineSegment);
+        if (!MayContainPointsNearLineSegment(node, lineLocal, maxDistanceToRay)) yield break;
 
-        var worstCaseDist = node.BoundingBoxExactLocal.Size3f.Length * 0.5 + maxDistanceToRay;
-        var d0 = rayLocal.GetMinimalDistanceTo((V3d)node.BoundingBoxExactLocal.Center);
-        if (d0 > worstCaseDist) yield break;
-
-        if (node.IsLeaf || node.Cell.Exponent == minCellExponent)
+        if (isTerminal)
         {
-            if (!node.HasKdTree) throw new Exception("No kd-tree. Error 575ebf66-6fdf-4656-85d6-b2a9e387fea9.");
-            
-            var closest = node.KdTree.Value.GetClosestToLine(
-                (V3f)s0Local, (V3f)s1Local,
-                (float)maxDistanceToRay,
-                node.PointCountCell
-                );
+            var ia = GetLineSegmentCandidateIndices(node, lineLocal, maxDistanceToRay);
+            if (ia.Count == 0) yield break;
 
-            if (closest.Count > 0)
+            var ps = GetSelectedGlobalPositions(node, ia);
+            var data =
+                ImmutableDictionary<Durable.Def, object>.Empty
+                .Add(GenericChunk.Defs.Positions3d, ps)
+                ;
+
+            var attributes = customAttributes.Where(node.Has).Select(def => (def, value: node.Properties[def]));
+            foreach (var (def, value) in attributes)
             {
-                var ia = closest.Map(x => (int)x.Index);
-                var ps = node.PositionsAbsolute.Subset(ia);
-                var data =
-                    ImmutableDictionary<Durable.Def, object>.Empty
-                    .Add(GenericChunk.Defs.Positions3d, ps)
-                    ;
-
-                var attributes = customAttributes.Where(node.Has).Select(def => (def, value: node.Properties[def]));
-                foreach (var (def, value) in attributes)
-                {
-                    data = data.Add(def, value.Subset(ia));
-                }
-
-                var chunk = new GenericChunk(data);
-
-                yield return chunk;
+                data = data.Add(def, value.Subset(ia));
             }
+
+            yield return new GenericChunk(data);
         }
         else // inner node
         {
@@ -249,6 +181,59 @@ public static partial class Queries
                 foreach (var x in xs) yield return x;
             }
         }
+    }
+
+    private static Line3d ToLocalLineSegment(IPointCloudNode node, Line3d lineSegment)
+        => new(lineSegment.P0 - node.Center, lineSegment.P1 - node.Center);
+
+    private static bool MayContainPointsNearLineSegment(
+        IPointCloudNode node, Line3d lineSegmentLocal, double maxDistanceToLineSegment
+        )
+    {
+        var boundsLocal = node.HasBoundingBoxExactLocal
+            ? (Box3d)node.BoundingBoxExactLocal
+            : node.BoundingBoxApproximate - node.Center;
+        var worstCaseDistance = boundsLocal.Size.Length * 0.5 + maxDistanceToLineSegment;
+        return lineSegmentLocal.GetMinimalDistanceTo(boundsLocal.Center) <= worstCaseDistance;
+    }
+
+    private static IReadOnlyList<int> GetLineSegmentCandidateIndices(
+        IPointCloudNode node, Line3d lineSegmentLocal, double maxDistanceToLineSegment
+        )
+    {
+        if (node.HasKdTree)
+        {
+            var closest = node.KdTree.Value.GetClosestToLine(
+                (V3f)lineSegmentLocal.P0,
+                (V3f)lineSegmentLocal.P1,
+                (float)maxDistanceToLineSegment,
+                node.PointCountCell
+                );
+            return closest.MapToArray(x => (int)x.Index);
+        }
+
+        var positionsLocal = node.Positions.Value;
+        var result = new List<int>();
+        for (var i = 0; i < positionsLocal.Length; i++)
+        {
+            if (lineSegmentLocal.GetMinimalDistanceTo((V3d)positionsLocal[i]) <= maxDistanceToLineSegment)
+            {
+                result.Add(i);
+            }
+        }
+        return result;
+    }
+
+    private static V3d[] GetSelectedGlobalPositions(IPointCloudNode node, IReadOnlyList<int> indices)
+    {
+        var centerGlobal = node.Center;
+        var positionsLocal = node.Positions.Value;
+        var result = new V3d[indices.Count];
+        for (var i = 0; i < result.Length; i++)
+        {
+            result[i] = centerGlobal + (V3d)positionsLocal[indices[i]];
+        }
+        return result;
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes #42.

Temporary and kd-tree-free point-set nodes can now answer finite line-segment queries correctly. Positionless inner nodes keep traversing, terminal nodes without kd-trees use the same finite-segment candidate semantics as the existing kd-tree path, and standard/custom results subset only the selected positions and attributes.

Regression coverage includes subdivided temporary trees, finite endpoint exclusion, kd-tree parity, `minCellExponent`, standard attributes, scalar and per-point part indices, and custom arrays. The complete Release suite passes (445 passed, 2 existing skips).

A warmed, CPU-pinned comparison on the existing kd-tree path returned identical result hashes. Median allocations fell from about 643 KB to 545 KB per fully materialized query; comparable timing samples showed no regression and generally improved throughput.
