### PR TITLE
Add PCA normal quality estimates

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,5 @@
+- [Normals] added PCA quality estimates for detecting degenerate neighbourhoods (#20)
+
 ### 5.6.3
 - Updated SharpCompress to 0.48.1 to address CVE-2026-44788
 
@@ -380,4 +382,3 @@
 
 ### 5.1.1
 - updated to FSharp.Data.Adaptive 1.1 and base 5.1 track
-

--- a/ai/GEOMETRY.md
+++ b/ai/GEOMETRY.md
@@ -162,12 +162,28 @@ V3f[] normals = await points.EstimateNormalsAsync(k: 16);
 // Estimate normals + local density
 var (normals, densities) = points.EstimateNormalsAndLocalDensity(k: 16);
 // densities[i] = average squared distance of k-nearest points to centroid
+
+// Estimate normals + scale-independent planar quality
+var (normals, qualities) = points.EstimateNormalsAndQuality(k: 16);
+for (var i = 0; i < normals.Length; i++)
+{
+    if (qualities[i] < 0.1f) normals[i] = V3f.ZAxis;
+}
 ```
+
+For sorted covariance eigenvalues `λmin ≤ λmiddle ≤ λmax`, normal quality is
+`clamp((λmiddle - λmin) / λmax, 0, 1)`. Quality is zero when `λmax` is
+non-positive or a required eigenvalue is non-finite. Values near zero indicate
+collinear, coincident, or otherwise ambiguous neighborhoods; values near one
+indicate a well-defined local plane. Choose the threshold for the scale and
+noise characteristics of the application. The metric is invariant under
+uniform scaling and translation.
 
 ### Gotchas
 
 - **k must be ≥ 3** – At least 3 points needed for PCA; throws `ArgumentOutOfRangeException` otherwise.
 - **Normal orientation is arbitrary** – Eigenvector for smallest eigenvalue has undefined sign; post-process to orient consistently.
+- **Quality does not orient normals** – `EstimateNormalsAndQuality` exposes PCA degeneracy, but the returned normal still has arbitrary sign.
 - **Temporary kd-tree cost** – Overloads without kd-tree parameter build one internally; reuse kd-tree for multiple calls.
 - **Local density is squared distance** – In `EstimateNormalsAndLocalDensity`, density values are not distances but squared distances.
 - **V3d arrays return V3f normals** – Normals are always `V3f[]` regardless of input precision.

--- a/src/Aardvark.Algodat.Tests/NormalsEstimationTests.cs
+++ b/src/Aardvark.Algodat.Tests/NormalsEstimationTests.cs
@@ -17,12 +17,179 @@ using NUnit.Framework.Legacy;
 using System;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace Aardvark.Geometry.Tests
 {
     [TestFixture]
     public class NormalsEstimationTests
     {
+        private static V3d[] CreatePlanarQualityPoints()
+        {
+            return (
+                from x in Enumerable.Range(-1, 3)
+                from y in Enumerable.Range(-1, 3)
+                select new V3d(x, y, 0.02 * x * y)
+                ).ToArray();
+        }
+
+        private static V3d[] CreateExactPlanePoints()
+        {
+            return (
+                from x in Enumerable.Range(-1, 3)
+                from y in Enumerable.Range(-1, 3)
+                select new V3d(x, y, 0.0)
+                ).ToArray();
+        }
+
+        private static void AssertNormalAndQualityResultsEqual(
+            (V3f[] normals, float[] qualities) expected,
+            (V3f[] normals, float[] qualities) actual,
+            float qualityTolerance = 0.0f
+            )
+        {
+            Assert.That(actual.normals, Has.Length.EqualTo(expected.normals.Length));
+            Assert.That(actual.qualities, Has.Length.EqualTo(expected.qualities.Length));
+            for (var i = 0; i < expected.normals.Length; i++)
+            {
+                Assert.That(
+                    Math.Abs(expected.normals[i].Dot(actual.normals[i])),
+                    Is.EqualTo(1.0f).Within(1e-5f)
+                    );
+                Assert.That(actual.qualities[i], Is.EqualTo(expected.qualities[i]).Within(qualityTolerance));
+            }
+        }
+
+        [Test]
+        public void EstimateNormalsAndQualityRecognizesPlanesAndDegenerateNeighborhoods()
+        {
+            var plane = CreateExactPlanePoints();
+            var (planeNormals, planeQualities) = plane.EstimateNormalsAndQuality(plane.Length);
+            Assert.That(planeNormals, Has.Length.EqualTo(plane.Length));
+            Assert.That(planeQualities, Has.All.EqualTo(1.0f).Within(1e-6f));
+            Assert.That(planeNormals, Has.All.Matches<V3f>(n => Math.Abs(n.Dot(V3f.ZAxis)) > 1.0f - 1e-6f));
+
+            var collinear = Enumerable.Range(-3, 7).Select(x => new V3d(x, 2.0 * x, -x)).ToArray();
+            var (_, lineQualities) = collinear.EstimateNormalsAndQuality(collinear.Length);
+            Assert.That(lineQualities, Has.All.EqualTo(0.0f));
+
+            var coincident = Enumerable.Repeat(new V3d(4.0, -2.0, 7.0), 5).ToArray();
+            var (_, coincidentQualities) = coincident.EstimateNormalsAndQuality(coincident.Length);
+            Assert.That(coincidentQualities, Has.All.EqualTo(0.0f));
+
+            var twoPoints = new[] { V3d.Zero, V3d.XAxis };
+            var (_, twoPointQualities) = twoPoints.EstimateNormalsAndQuality(3);
+            Assert.That(twoPointQualities, Has.All.EqualTo(0.0f));
+        }
+
+        [Test]
+        public void EstimateNormalsAndQualitySeparatesNearLinearAndNoisyPlanarNeighborhoods()
+        {
+            var nearLinear = Enumerable.Range(-4, 9)
+                .Select(x => new V3d(x, (x & 1) == 0 ? 0.01 : -0.01, 0.0))
+                .ToArray();
+            var (_, lineQualities) = nearLinear.EstimateNormalsAndQuality(nearLinear.Length);
+            Assert.That(lineQualities, Has.All.GreaterThan(0.0f));
+            Assert.That(lineQualities, Has.All.LessThan(0.001f));
+
+            var noisyPlane = CreatePlanarQualityPoints();
+            var (_, planeQualities) = noisyPlane.EstimateNormalsAndQuality(noisyPlane.Length);
+            Assert.That(planeQualities, Has.All.GreaterThan(0.99f));
+            Assert.That(planeQualities, Has.All.LessThanOrEqualTo(1.0f));
+        }
+
+        [Test]
+        public void EstimateNormalsAndQualityIsScaleAndTranslationInvariant()
+        {
+            var points = CreatePlanarQualityPoints();
+            var transformed = points
+                .Select(p => p * 37.0 + new V3d(1_000_000.0, -2_000_000.0, 3_000_000.0))
+                .ToArray();
+
+            var original = points.EstimateNormalsAndQuality(points.Length);
+            var changed = transformed.EstimateNormalsAndQuality(transformed.Length);
+            AssertNormalAndQualityResultsEqual(original, changed, qualityTolerance: 1e-5f);
+        }
+
+        [Test]
+        public void EstimateNormalsAndQualityHasFloatDoubleParity()
+        {
+            var pointsD = CreatePlanarQualityPoints();
+            var pointsF = pointsD.Map(p => (V3f)p);
+            var resultD = pointsD.EstimateNormalsAndQuality(pointsD.Length, pointsD.BuildKdTree());
+            var resultF = pointsF.EstimateNormalsAndQuality(pointsF.Length, pointsF.BuildKdTree());
+            AssertNormalAndQualityResultsEqual(resultD, resultF, qualityTolerance: 1e-5f);
+        }
+
+        [Test]
+        public async Task EstimateNormalsAndQualityVariantsAgree()
+        {
+            var pointsD = CreatePlanarQualityPoints();
+            var pointsF = pointsD.Map(p => (V3f)p);
+            var kdTreeD = pointsD.BuildKdTree();
+            var kdTreeF = pointsF.BuildKdTree();
+
+            var expectedD = pointsD.EstimateNormalsAndQuality(pointsD.Length, kdTreeD);
+            AssertNormalAndQualityResultsEqual(expectedD, pointsD.EstimateNormalsAndQuality(pointsD.Length));
+            AssertNormalAndQualityResultsEqual(expectedD, await pointsD.EstimateNormalsAndQualityAsync(pointsD.Length, kdTreeD));
+            AssertNormalAndQualityResultsEqual(expectedD, await pointsD.EstimateNormalsAndQualityAsync(pointsD.Length));
+
+            var expectedF = pointsF.EstimateNormalsAndQuality(pointsF.Length, kdTreeF);
+            AssertNormalAndQualityResultsEqual(expectedF, pointsF.EstimateNormalsAndQuality(pointsF.Length));
+            AssertNormalAndQualityResultsEqual(expectedF, await pointsF.EstimateNormalsAndQualityAsync(pointsF.Length, kdTreeF));
+            AssertNormalAndQualityResultsEqual(expectedF, await pointsF.EstimateNormalsAndQualityAsync(pointsF.Length));
+        }
+
+        [Test]
+        public async Task EstimateNormalsAndQualityValidatesInputsAndHandlesEmptyArrays()
+        {
+            Assert.Throws<ArgumentNullException>(() => Normals.EstimateNormalsAndQuality((V3f[])null!, 3));
+            Assert.Throws<ArgumentNullException>(() => Normals.EstimateNormalsAndQuality((V3d[])null!, 3));
+            Assert.Throws<ArgumentOutOfRangeException>(() => Array.Empty<V3f>().EstimateNormalsAndQuality(2));
+            Assert.Throws<ArgumentOutOfRangeException>(() => Array.Empty<V3d>().EstimateNormalsAndQuality(2));
+
+            var pointsF = CreateExactPlanePoints().Map(p => (V3f)p);
+            var pointsD = CreateExactPlanePoints();
+            Assert.Throws<ArgumentNullException>(() => pointsF.EstimateNormalsAndQuality(3, null!));
+            Assert.Throws<ArgumentNullException>(() => pointsD.EstimateNormalsAndQuality(3, null!));
+            Assert.ThrowsAsync<ArgumentNullException>(async () => await Normals.EstimateNormalsAndQualityAsync((V3f[])null!, 3));
+            Assert.ThrowsAsync<ArgumentNullException>(async () => await Normals.EstimateNormalsAndQualityAsync((V3d[])null!, 3));
+            Assert.ThrowsAsync<ArgumentNullException>(async () => await pointsF.EstimateNormalsAndQualityAsync(3, null!));
+            Assert.ThrowsAsync<ArgumentNullException>(async () => await pointsD.EstimateNormalsAndQualityAsync(3, null!));
+            Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await pointsF.EstimateNormalsAndQualityAsync(2));
+            Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await pointsD.EstimateNormalsAndQualityAsync(2));
+
+            var emptyF = Array.Empty<V3f>().EstimateNormalsAndQuality(3);
+            var emptyD = Array.Empty<V3d>().EstimateNormalsAndQuality(3);
+            var emptyAsyncF = await Array.Empty<V3f>().EstimateNormalsAndQualityAsync(3);
+            var emptyAsyncD = await Array.Empty<V3d>().EstimateNormalsAndQualityAsync(3);
+            Assert.That(emptyF.normals, Is.Empty);
+            Assert.That(emptyF.qualities, Is.Empty);
+            Assert.That(emptyD.normals, Is.Empty);
+            Assert.That(emptyD.qualities, Is.Empty);
+            Assert.That(emptyAsyncF.normals, Is.Empty);
+            Assert.That(emptyAsyncF.qualities, Is.Empty);
+            Assert.That(emptyAsyncD.normals, Is.Empty);
+            Assert.That(emptyAsyncD.qualities, Is.Empty);
+        }
+
+        [Test]
+        public void EstimateNormalsAndQualityPreservesExistingNormalResults()
+        {
+            var pointsD = CreatePlanarQualityPoints();
+            var pointsF = pointsD.Map(p => (V3f)p);
+            var kdTreeD = pointsD.BuildKdTree();
+            var kdTreeF = pointsF.BuildKdTree();
+
+            var existingD = pointsD.EstimateNormals(pointsD.Length, kdTreeD);
+            var existingF = pointsF.EstimateNormals(pointsF.Length, kdTreeF);
+            var qualityD = pointsD.EstimateNormalsAndQuality(pointsD.Length, kdTreeD);
+            var qualityF = pointsF.EstimateNormalsAndQuality(pointsF.Length, kdTreeF);
+
+            Assert.That(qualityD.normals, Is.EqualTo(existingD));
+            Assert.That(qualityF.normals, Is.EqualTo(existingF));
+        }
+
         [Test]
         public void CanEstimateNormals_FromZeroToThreePoints()
         {

--- a/src/Aardvark.Geometry.Normals/Normals.cs
+++ b/src/Aardvark.Geometry.Normals/Normals.cs
@@ -306,6 +306,209 @@ namespace Aardvark.Geometry
 
         #endregion
 
+        #region EstimateNormalsAndQuality
+
+        /// <summary>
+        /// Estimates normals and their local planar quality from k-nearest neighbours.
+        /// </summary>
+        /// <remarks>
+        /// For sorted covariance eigenvalues λmin ≤ λmiddle ≤ λmax, quality is
+        /// clamp((λmiddle - λmin) / λmax, 0, 1). Quality is zero if λmax is
+        /// non-positive or a required eigenvalue is non-finite. Zero denotes a
+        /// collinear, coincident, or invalid neighbourhood; values near one denote a
+        /// well-defined local plane. Normal orientation is arbitrary because eigenvector
+        /// signs are undefined. A caller can, for example, replace normals whose quality
+        /// is below a chosen application-specific threshold.
+        /// </remarks>
+        /// <example>
+        /// <code>
+        /// var (normals, qualities) = points.EstimateNormalsAndQuality(16, kdTree);
+        /// for (var i = 0; i &lt; normals.Length; i++)
+        ///     if (qualities[i] &lt; 0.1f) normals[i] = V3f.ZAxis;
+        /// </code>
+        /// </example>
+        public static (V3f[] normals, float[] qualities) EstimateNormalsAndQuality(
+            this V3f[] points, int k, PointRkdTreeF<V3f[], V3f> kdtree
+            )
+        {
+            if (points == null) throw new ArgumentNullException(nameof(points));
+            if (k < 3) throw new ArgumentOutOfRangeException($"Expected k >= 3, but k is {k}.");
+            if (kdtree == null) throw new ArgumentNullException(nameof(kdtree));
+
+            var ns = points.Length > 0 ? new V3f[points.Length] : Array.Empty<V3f>();
+            var qs = points.Length > 0 ? new float[points.Length] : Array.Empty<float>();
+            var count = Math.Min(k, points.Length);
+
+            for (var i = 0; i < points.Length; i++)
+            {
+                var closest = kdtree.GetClosest(points[i], float.MaxValue, count);
+                if (closest.Count == 0) continue;
+
+                var c = points[closest[0].Index];
+                for (var j = 1; j < closest.Count; j++) c += points[closest[j].Index];
+                c /= closest.Count;
+
+                var cvm = M33f.Zero;
+                for (var j = 0; j < closest.Count; j++) cvm.AddOuterProduct(points[closest[j].Index] - c);
+                cvm /= closest.Count;
+
+                Eigensystems.Dsyevh3((M33d)cvm, out M33d eigenvectors, out V3d eigenvalues);
+                (ns[i], qs[i]) = SelectNormalAndQuality(eigenvectors, eigenvalues);
+            }
+
+            return (normals: ns, qualities: qs);
+        }
+
+        /// <summary>
+        /// Estimates normals and quality values in [0, 1] from k-nearest neighbours.
+        /// </summary>
+        /// <remarks>
+        /// Quality is clamp((λmiddle - λmin) / λmax, 0, 1) for the sorted covariance
+        /// eigenvalues. Quality is zero if λmax is non-positive or a required eigenvalue
+        /// is non-finite. Zero identifies degenerate or invalid neighbourhoods and values
+        /// near one identify well-defined local planes. Normal orientation is arbitrary.
+        /// </remarks>
+        public static (V3f[] normals, float[] qualities) EstimateNormalsAndQuality(
+            this V3d[] points, int k, PointRkdTreeD<V3d[], V3d> kdtree
+            )
+        {
+            if (points == null) throw new ArgumentNullException(nameof(points));
+            if (k < 3) throw new ArgumentOutOfRangeException($"Expected k >= 3, but k is {k}.");
+            if (kdtree == null) throw new ArgumentNullException(nameof(kdtree));
+
+            var ns = points.Length > 0 ? new V3f[points.Length] : Array.Empty<V3f>();
+            var qs = points.Length > 0 ? new float[points.Length] : Array.Empty<float>();
+            var count = Math.Min(k, points.Length);
+
+            for (var i = 0; i < points.Length; i++)
+            {
+                var closest = kdtree.GetClosest(points[i], float.MaxValue, count);
+                if (closest.Count == 0) continue;
+
+                var c = points[closest[0].Index];
+                for (var j = 1; j < closest.Count; j++) c += points[closest[j].Index];
+                c /= closest.Count;
+
+                var cvm = M33d.Zero;
+                for (var j = 0; j < closest.Count; j++) cvm.AddOuterProduct(points[closest[j].Index] - c);
+                cvm /= closest.Count;
+
+                Eigensystems.Dsyevh3(cvm, out M33d eigenvectors, out V3d eigenvalues);
+                (ns[i], qs[i]) = SelectNormalAndQuality(eigenvectors, eigenvalues);
+            }
+
+            return (normals: ns, qualities: qs);
+        }
+
+        /// <summary>
+        /// Asynchronously estimates normals and planar quality using a supplied kd-tree.
+        /// Quality is in [0, 1]; zero is degenerate and values near one are planar.
+        /// Normal orientation is arbitrary.
+        /// </summary>
+        public static async Task<(V3f[] normals, float[] qualities)> EstimateNormalsAndQualityAsync(
+            this V3f[] points, int k, PointRkdTreeF<V3f[], V3f> kdtree
+            )
+        {
+            if (points == null) throw new ArgumentNullException(nameof(points));
+            if (k < 3) throw new ArgumentOutOfRangeException($"Expected k >= 3, but k is {k}.");
+            if (kdtree == null) throw new ArgumentNullException(nameof(kdtree));
+            return await Task.Run(() => EstimateNormalsAndQuality(points, k, kdtree));
+        }
+
+        /// <summary>
+        /// Asynchronously estimates normals and planar quality using a supplied kd-tree.
+        /// Quality is in [0, 1]; zero is degenerate and values near one are planar.
+        /// Normal orientation is arbitrary.
+        /// </summary>
+        public static async Task<(V3f[] normals, float[] qualities)> EstimateNormalsAndQualityAsync(
+            this V3d[] points, int k, PointRkdTreeD<V3d[], V3d> kdtree
+            )
+        {
+            if (points == null) throw new ArgumentNullException(nameof(points));
+            if (k < 3) throw new ArgumentOutOfRangeException($"Expected k >= 3, but k is {k}.");
+            if (kdtree == null) throw new ArgumentNullException(nameof(kdtree));
+            return await Task.Run(() => EstimateNormalsAndQuality(points, k, kdtree));
+        }
+
+        /// <summary>
+        /// Estimates normals and planar quality, building a temporary kd-tree.
+        /// Quality is in [0, 1]; zero is degenerate and values near one are planar.
+        /// Normal orientation is arbitrary.
+        /// </summary>
+        public static (V3f[] normals, float[] qualities) EstimateNormalsAndQuality(this V3f[] points, int k)
+        {
+            if (points == null) throw new ArgumentNullException(nameof(points));
+            if (k < 3) throw new ArgumentOutOfRangeException($"Expected k >= 3, but k is {k}.");
+            if (points.Length == 0) return (Array.Empty<V3f>(), Array.Empty<float>());
+            return EstimateNormalsAndQuality(points, k, points.BuildKdTree());
+        }
+
+        /// <summary>
+        /// Estimates normals and planar quality, building a temporary kd-tree.
+        /// Quality is in [0, 1]; zero is degenerate and values near one are planar.
+        /// Normal orientation is arbitrary.
+        /// </summary>
+        public static (V3f[] normals, float[] qualities) EstimateNormalsAndQuality(this V3d[] points, int k)
+        {
+            if (points == null) throw new ArgumentNullException(nameof(points));
+            if (k < 3) throw new ArgumentOutOfRangeException($"Expected k >= 3, but k is {k}.");
+            if (points.Length == 0) return (Array.Empty<V3f>(), Array.Empty<float>());
+            return EstimateNormalsAndQuality(points, k, points.BuildKdTree());
+        }
+
+        /// <summary>
+        /// Asynchronously estimates normals and planar quality, building a temporary kd-tree.
+        /// Quality is in [0, 1]; zero is degenerate and values near one are planar.
+        /// Normal orientation is arbitrary.
+        /// </summary>
+        public static async Task<(V3f[] normals, float[] qualities)> EstimateNormalsAndQualityAsync(this V3f[] points, int k)
+        {
+            if (points == null) throw new ArgumentNullException(nameof(points));
+            if (k < 3) throw new ArgumentOutOfRangeException($"Expected k >= 3, but k is {k}.");
+            if (points.Length == 0) return (Array.Empty<V3f>(), Array.Empty<float>());
+            return await EstimateNormalsAndQualityAsync(points, k, await points.BuildKdTreeAsync());
+        }
+
+        /// <summary>
+        /// Asynchronously estimates normals and planar quality, building a temporary kd-tree.
+        /// Quality is in [0, 1]; zero is degenerate and values near one are planar.
+        /// Normal orientation is arbitrary.
+        /// </summary>
+        public static async Task<(V3f[] normals, float[] qualities)> EstimateNormalsAndQualityAsync(this V3d[] points, int k)
+        {
+            if (points == null) throw new ArgumentNullException(nameof(points));
+            if (k < 3) throw new ArgumentOutOfRangeException($"Expected k >= 3, but k is {k}.");
+            if (points.Length == 0) return (Array.Empty<V3f>(), Array.Empty<float>());
+            return await EstimateNormalsAndQualityAsync(points, k, await points.BuildKdTreeAsync());
+        }
+
+        private static (V3f normal, float quality) SelectNormalAndQuality(M33d eigenvectors, V3d eigenvalues)
+        {
+            var normal = (V3f)((eigenvalues.X < eigenvalues.Y)
+                ? ((eigenvalues.X < eigenvalues.Z) ? eigenvectors.C0 : eigenvectors.C2)
+                : ((eigenvalues.Y < eigenvalues.Z) ? eigenvectors.C1 : eigenvectors.C2));
+
+            var minimum = eigenvalues.X;
+            var middle = eigenvalues.Y;
+            var maximum = eigenvalues.Z;
+            if (minimum > middle) (minimum, middle) = (middle, minimum);
+            if (middle > maximum) (middle, maximum) = (maximum, middle);
+            if (minimum > middle) (minimum, middle) = (middle, minimum);
+
+            if (!IsFinite(minimum) || !IsFinite(middle) || !IsFinite(maximum) || maximum <= 0.0)
+                return (normal, 0.0f);
+
+            var quality = (middle - minimum) / maximum;
+            if (quality <= 0.0) return (normal, 0.0f);
+            if (quality >= 1.0) return (normal, 1.0f);
+            return (normal, (float)quality);
+        }
+
+        private static bool IsFinite(double value)
+            => !double.IsNaN(value) && !double.IsInfinity(value);
+
+        #endregion
+
         #region EstimateNormalsAndLocalDensity
 
         /// <summary>


### PR DESCRIPTION
Fixes #20.

Adds `EstimateNormalsAndQuality` and asynchronous counterparts for `V3f[]` and `V3d[]`, with both supplied and temporary kd-trees. The returned scale-independent quality is `clamp((λmiddle - λmin) / λmax, 0, 1)`; degenerate or invalid neighborhoods report zero while the normal keeps the existing arbitrary-sign PCA convention.

The existing `EstimateNormals` signatures and implementation remain unchanged. Regression coverage includes exact planes, collinear/coincident and two-point neighborhoods, near-linear and noisy-planar data, scale/translation invariance, float/double and sync/async parity, supplied/temporary kd-tree parity, validation, and exact equivalence with existing normal results.

Release validation: 449 passed, 2 existing skips. A warmed reused-kd-tree comparison kept the existing API allocation-identical at 1,336,458 bytes per call; median time changed from 5.2984 ms to 5.3489 ms (about 1%). The quality API measured 5.5014 ms and added 9,136 bytes for 2,304 quality values, essentially the output array cost.
