### PR TITLE
Keep filtered custom attributes aligned

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,5 @@
+- [PointSet] kept custom per-point attributes aligned in filtered views (#47)
+
 ### 5.6.3
 - Updated SharpCompress to 0.48.1 to address CVE-2026-44788
 

--- a/ai/POINT_CLOUDS.md
+++ b/ai/POINT_CLOUDS.md
@@ -307,6 +307,10 @@ var updatedNode = node.With(new Dictionary<Durable.Def, object>
 updatedNode = updatedNode.WriteToStore();  // Now persisted
 ```
 
+### 6. Custom Attributes in Filtered Views
+
+`FilteredNode.Properties` and `FilteredNode.TryGetValue()` keep custom per-point arrays aligned with filtered positions. Partial, empty, and nested views project arrays through the same source indices and preserve source order and element type. Projected values are cached and shared by both accessors. Scalar, reference, and structural metadata such as `Octree.SubnodesGuids` remains unchanged; fully included views return the backing node's dictionary and values directly.
+
 ## See Also
 
 - [IMPORTERS.md](IMPORTERS.md) - Importing point clouds from various file formats

--- a/src/Aardvark.Algodat.Tests/ViewsTests/ViewsFilterTests.cs
+++ b/src/Aardvark.Algodat.Tests/ViewsTests/ViewsFilterTests.cs
@@ -18,6 +18,7 @@ using Aardvark.Geometry.Points;
 using NUnit.Framework;
 using NUnit.Framework.Legacy;
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 
@@ -27,11 +28,27 @@ namespace Aardvark.Geometry.Tests
     public class ViewsFilterTests
     {
         private static readonly Random r = new();
+        private static readonly Durable.Def CustomIntAttribute = new(
+            new Guid("ef96d640-cb31-4b4a-9a01-4c0bf17f52b1"),
+            "Tests.CustomIntAttribute", "Custom per-point integer values.",
+            Durable.Primitives.Int32Array.Id, true
+            );
+        private static readonly Durable.Def CustomVectorAttribute = new(
+            new Guid("21877b7e-aee6-47fe-b12f-28668d7fca6c"),
+            "Tests.CustomVectorAttribute", "Custom per-point vector values.",
+            Durable.Aardvark.V3fArray.Id, true
+            );
+
         private static V3f RandomPosition() => new(r.NextDouble(), r.NextDouble(), r.NextDouble());
         private static V3f[] RandomPositions(int n) => new V3f[n].SetByIndex(_ => RandomPosition());
         private static int[] RandomIntensities(int n) => new int[n].SetByIndex(_ => -999 + r.Next(1998));
 
-        private static IPointCloudNode CreateNode(Storage storage, V3f[] psGlobal, int[] intensities = null)
+        private static IPointCloudNode CreateNode(
+            Storage storage,
+            V3f[] psGlobal,
+            int[] intensities = null,
+            IReadOnlyDictionary<Durable.Def, object> properties = null
+            )
         {
             var id = Guid.NewGuid();
             var cell = new Cell(psGlobal);
@@ -66,6 +83,8 @@ namespace Aardvark.Geometry.Tests
                 storage.Add(jsId, intensities);
                 data = data.Add(Durable.Octree.Intensities1iReference, jsId);
             }
+
+            if (properties != null) data = data.AddRange(properties);
 
             var result = new PointSetNode(data, storage, writeToStore: true);
             return result;
@@ -353,6 +372,112 @@ namespace Aardvark.Geometry.Tests
         #region FilteredNode
 
         [Test]
+        public void CustomAttributes_AllInsideUseBackingValues()
+        {
+            var storage = PointCloud.CreateInMemoryStore(cache: default);
+            var positions = CustomAttributePositions();
+            var (integers, vectors) = CustomAttributeValues();
+            var source = CreateNode(storage, positions, properties: CustomProperties(integers, vectors));
+            var filtered = FilteredNode.CreateTransient(source, new FilterInsideBox3d(source.BoundingBoxExactGlobal));
+
+            ClassicAssert.AreSame(source.Properties, filtered.Properties);
+            ClassicAssert.IsTrue(filtered.TryGetValue(CustomIntAttribute, out var integerValue));
+            ClassicAssert.IsTrue(filtered.TryGetValue(CustomVectorAttribute, out var vectorValue));
+            ClassicAssert.AreSame(integers, integerValue);
+            ClassicAssert.AreSame(vectors, vectorValue);
+        }
+
+        [Test]
+        public void CustomAttributes_PartialAndEmptyStayAligned()
+        {
+            var storage = PointCloud.CreateInMemoryStore(cache: default);
+            var positions = CustomAttributePositions();
+            var (integers, vectors) = CustomAttributeValues();
+            var source = CreateNode(storage, positions, properties: CustomProperties(integers, vectors));
+
+            var partial = FilteredNode.CreateTransient(source, new FilterInsideBox3d(
+                new Box3d(new V3d(0.3, -1.0, -1.0), new V3d(0.8, 1.0, 1.0))
+                ));
+            AssertCustomAttributes(partial, new[] { 40, 70 }, new[] { vectors[1], vectors[2] });
+
+            var empty = FilteredNode.CreateTransient(source, new FilterInsideBox3d(
+                new Box3d(new V3d(2.0, -1.0, -1.0), new V3d(3.0, 1.0, 1.0))
+                ));
+            AssertCustomAttributes(empty, Array.Empty<int>(), Array.Empty<V3f>());
+        }
+
+        [Test]
+        public void CustomAttributes_NestedAndEncodedViewsStayAligned()
+        {
+            var storage = PointCloud.CreateInMemoryStore(cache: default);
+            var positions = CustomAttributePositions();
+            var (integers, vectors) = CustomAttributeValues();
+            var source = CreateNode(storage, positions, properties: CustomProperties(integers, vectors));
+            var first = FilteredNode.CreateTransient(source, new FilterInsideBox3d(
+                new Box3d(new V3d(0.3, -1.0, -1.0), new V3d(1.0, 1.0, 1.0))
+                ));
+            var nested = FilteredNode.CreateTransient(first, new FilterInsideBox3d(
+                new Box3d(new V3d(0.6, -1.0, -1.0), new V3d(1.0, 1.0, 1.0))
+                ));
+
+            AssertCustomAttributes(nested, new[] { 70, 90 }, new[] { vectors[2], vectors[3] });
+
+            var decoded = FilteredNode.Decode(storage, first.Encode());
+            AssertCustomAttributes(decoded, new[] { 40, 70, 90 }, new[] { vectors[1], vectors[2], vectors[3] });
+        }
+
+        [Test]
+        public void CustomAttributes_PreserveStructuralMetadata()
+        {
+            var storage = PointCloud.CreateInMemoryStore(cache: default);
+            var positions = new V3f[8].SetByIndex(i => new V3f((i + 0.5) / 8.0, 0.0, 0.0));
+            var subnodeIds = new Guid[8];
+            var properties = ImmutableDictionary<Durable.Def, object>.Empty
+                .Add(Durable.Octree.SubnodesGuids, subnodeIds);
+            var source = CreateNode(storage, positions, properties: properties);
+            var filtered = FilteredNode.CreateTransient(source, new FilterInsideBox3d(
+                new Box3d(new V3d(0.25, -1.0, -1.0), new V3d(0.75, 1.0, 1.0))
+                ));
+
+            ClassicAssert.AreSame(subnodeIds, filtered.Properties[Durable.Octree.SubnodesGuids]);
+            ClassicAssert.IsTrue(filtered.TryGetValue(Durable.Octree.SubnodesGuids, out var value));
+            ClassicAssert.AreSame(subnodeIds, value);
+            ClassicAssert.AreSame(source.Properties[Durable.Octree.NodeId], filtered.Properties[Durable.Octree.NodeId]);
+            ClassicAssert.AreSame(source.Properties[Durable.Octree.PositionsLocal3fReference], filtered.Properties[Durable.Octree.PositionsLocal3fReference]);
+        }
+
+        [Test]
+        public void CustomLineQueryKeepsFilteredAttributesAligned()
+        {
+            var storage = PointCloud.CreateInMemoryStore(cache: default);
+            var positions = CustomAttributePositions();
+            var (integers, vectors) = CustomAttributeValues();
+            var source = CreateNode(storage, positions, properties: CustomProperties(integers, vectors));
+            var filtered = FilteredNode.CreateTransient(source, new FilterInsideBox3d(
+                new Box3d(new V3d(0.6, -1.0, -1.0), new V3d(1.0, 1.0, 1.0))
+                ));
+
+            var chunks = filtered.QueryPointsNearLineSegmentCustom(
+                new Line3d(new V3d(0.7, -1.0, 0.0), new V3d(0.7, 1.0, 0.0)),
+                0.25,
+                CustomIntAttribute
+                ).ToArray();
+            var pairs = chunks
+                .SelectMany(chunk => chunk.PositionsAsV3d.Zip(
+                    (int[])chunk.Data[CustomIntAttribute],
+                    (position, value) => (position, value)
+                    ))
+                .OrderBy(pair => pair.position.X)
+                .ToArray();
+
+            ClassicAssert.AreEqual(2, pairs.Length);
+            ClassicAssert.AreEqual(0.7, pairs[0].position.X, 1e-6);
+            ClassicAssert.AreEqual(70, pairs[0].value);
+            ClassicAssert.AreEqual(0.9, pairs[1].position.X, 1e-6);
+            ClassicAssert.AreEqual(90, pairs[1].value);
+        }
+
+        [Test]
         public void EncodeDecodeRoundtrip()
         {
             var storage = PointCloud.CreateInMemoryStore(cache: default);
@@ -373,6 +498,47 @@ namespace Aardvark.Geometry.Tests
             var fFilterJson = f.Filter.Serialize().ToString();
             var gFilterJson = g.Filter.Serialize().ToString();
             ClassicAssert.IsTrue(fFilterJson == gFilterJson);
+        }
+
+        private static V3f[] CustomAttributePositions() => new[]
+        {
+            new V3f(0.1, 0.0, 0.0),
+            new V3f(0.4, 0.0, 0.0),
+            new V3f(0.7, 0.0, 0.0),
+            new V3f(0.9, 0.0, 0.0)
+        };
+
+        private static (int[] integers, V3f[] vectors) CustomAttributeValues() => (
+            new[] { 10, 40, 70, 90 },
+            new[]
+            {
+                new V3f(1.0, 10.0, 100.0),
+                new V3f(4.0, 40.0, 400.0),
+                new V3f(7.0, 70.0, 700.0),
+                new V3f(9.0, 90.0, 900.0)
+            }
+            );
+
+        private static ImmutableDictionary<Durable.Def, object> CustomProperties(int[] integers, V3f[] vectors)
+            => ImmutableDictionary<Durable.Def, object>.Empty
+                .Add(CustomIntAttribute, integers)
+                .Add(CustomVectorAttribute, vectors);
+
+        private static void AssertCustomAttributes(IPointCloudNode node, int[] expectedIntegers, V3f[] expectedVectors)
+        {
+            ClassicAssert.IsTrue(node.TryGetValue(CustomIntAttribute, out var integerValue));
+            var integers = (int[])integerValue;
+            var properties = node.Properties;
+            ClassicAssert.AreSame(integers, properties[CustomIntAttribute]);
+            ClassicAssert.AreSame(properties, node.Properties);
+            ClassicAssert.AreEqual(typeof(int[]), integers.GetType());
+            CollectionAssert.AreEqual(expectedIntegers, integers);
+
+            var vectors = (V3f[])properties[CustomVectorAttribute];
+            ClassicAssert.IsTrue(node.TryGetValue(CustomVectorAttribute, out var vectorValue));
+            ClassicAssert.AreSame(vectors, vectorValue);
+            ClassicAssert.AreEqual(typeof(V3f[]), vectors.GetType());
+            CollectionAssert.AreEqual(expectedVectors, vectors);
         }
 
         #endregion

--- a/src/Aardvark.Geometry.PointSet/Views/FilteredNode.cs
+++ b/src/Aardvark.Geometry.PointSet/Views/FilteredNode.cs
@@ -21,6 +21,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text.Json.Serialization;
 using static Aardvark.Data.Durable;
 
@@ -88,6 +89,8 @@ public class FilteredNode : IPointCloudNode
     #region Properties
 
     private PersistentRef<IPointCloudNode>?[]? m_subnodes_cache;
+    private IReadOnlyDictionary<Def, object>? m_properties_cache;
+    private Dictionary<Guid, object>? m_property_values_cache;
 
     private readonly HashSet<int>? m_activePoints;
 
@@ -214,10 +217,82 @@ public class FilteredNode : IPointCloudNode
     public bool Has(Def what) => Node.Has(what);
 
     /// <summary></summary>
-    public bool TryGetValue(Def what, [NotNullWhen(true)]out object? o) => Node.TryGetValue(what, out o);
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool TryGetValue(Def what, [NotNullWhen(true)]out object? o)
+        => m_activePoints == null
+            ? Node.TryGetValue(what, out o)
+            : TryGetFilteredValue(what, out o);
+
+    private bool TryGetFilteredValue(Def what, [NotNullWhen(true)]out object? o)
+    {
+        if (m_properties_cache != null) return m_properties_cache.TryGetValue(what, out o);
+        if (m_property_values_cache?.TryGetValue(what.Id, out o) == true) return true;
+        if (!Node.TryGetValue(what, out var value))
+        {
+            o = null;
+            return false;
+        }
+
+        o = GetPropertyValue(what, value);
+        return true;
+    }
 
     /// <summary></summary>
-    public IReadOnlyDictionary<Def, object> Properties => Node.Properties;
+    public IReadOnlyDictionary<Def, object> Properties
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => m_properties_cache ?? (m_activePoints == null
+            ? m_properties_cache = Node.Properties
+            : CreateProperties());
+    }
+
+    private IReadOnlyDictionary<Def, object> CreateProperties()
+    {
+        var result = ImmutableDictionary.CreateBuilder<Def, object>();
+        foreach (var property in Node.Properties)
+        {
+            result.Add(property.Key, GetPropertyValue(property.Key, property.Value));
+        }
+
+        return m_properties_cache = result.ToImmutable();
+    }
+
+    private object GetPropertyValue(Def def, object value)
+    {
+        m_property_values_cache ??= [];
+        if (m_property_values_cache.TryGetValue(def.Id, out var result)) return result;
+
+        // Custom per-point arrays have one element per backing position. Subnode IDs are
+        // structural metadata and must remain unchanged even for nodes containing 8 points.
+        if (def.IsArray &&
+            def != Octree.SubnodesGuids &&
+            value is Array source &&
+            source.Rank == 1 &&
+            source.Length == Node.PointCountCell)
+        {
+            result = Subset(source, SubsetIndexArray!);
+        }
+        else
+        {
+            result = value;
+        }
+
+        m_property_values_cache.Add(def.Id, result);
+        return result;
+    }
+
+    private static Array Subset(Array source, int[] indices)
+    {
+        var elementType = source.GetType().GetElementType() ?? throw new InvalidOperationException(
+            $"Expected one-dimensional array, but got {source.GetType()}. Invariant 38bf7906-0a2a-4200-8bec-f2639b5a2ccd."
+            );
+        var result = Array.CreateInstance(elementType, indices.Length);
+        for (var i = 0; i < indices.Length; i++)
+        {
+            Array.Copy(source, indices[i], result, i, 1);
+        }
+        return result;
+    }
 
     /// <summary></summary>
     public PersistentRef<IPointCloudNode>[]? Subnodes


### PR DESCRIPTION
## Summary
- project custom per-point arrays through the same sorted source indices as filtered positions
- cache projected arrays across `Properties` and `TryGetValue` while preserving element types and source order
- retain scalar, reference, and structural metadata unchanged, including `SubnodesGuids`
- keep fully included views on backing dictionaries and values
- cover full, partial, empty, nested, encoded/decoded, and downstream custom line-query behavior

## Performance
A warmed 5,000,000-access CPU-time microbenchmark (median of 9 rounds) remained allocation-free and showed no regression:

| Access path | Before | After |
| --- | ---: | ---: |
| full `Properties` | 22.82 ns | 20.68 ns |
| full `TryGetValue` | 26.65 ns | 21.42 ns |
| repeated partial `Properties` | 21.77 ns | 20.82 ns |
| repeated partial `TryGetValue` | 23.42 ns | 16.86 ns |

All four paths allocated 0 bytes during measurement.

## Validation
- focused filtered-view tests: 29 passed
- complete Release suite: 447 passed, 2 existing skips
- complete Release solution build with warnings as errors: 0 warnings, 0 errors

Fixes #47.