### PR TITLE
Repair arbitrary-stride XY grid queries

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,5 @@
+- [PointSet] fixed `QueryGridXY` result access, LoD forwarding, and half-open tile ownership (#49)
+
 ### 5.6.3
 - Updated SharpCompress to 0.48.1 to address CVE-2026-44788
 

--- a/ai/POINT_CLOUDS.md
+++ b/ai/POINT_CLOUDS.md
@@ -90,6 +90,22 @@ foreach (var chunk in pointSet.QueryPointsInsideBox(queryBox))
 long count = pointSet.CountPointsInsideBox(queryBox);
 ```
 
+### Partitioning XY with Arbitrary Strides
+
+```csharp
+var stride = new V2d(10.0, 5.0);
+foreach (var tile in pointSet.QueryGridXY(stride, minCellExponent: -4))
+{
+    Box2d footprint = tile.Footprint;
+    foreach (var chunk in tile.Points)
+    {
+        // Process this tile's points.
+    }
+}
+```
+
+`QueryGridXY` assigns every point to the unique half-open tile `[Min, Max)`, so a point on an X or Y boundary belongs to the tile beginning at that boundary. Tile indices use `floor(position / stride)`, including for negative coordinates. `minCellExponent` selects the octree LoD front to partition. The `IPointCloudNode` overload also accepts `maxInMemoryPointCount`; this only controls when candidate nodes are materialized into an in-memory chunk and does not change tile ownership or results. Tile and point enumeration remain lazy.
+
 ### Spatial Queries with KD-Tree
 
 ```csharp

--- a/src/Aardvark.Algodat.Tests/QueryTests.cs
+++ b/src/Aardvark.Algodat.Tests/QueryTests.cs
@@ -1178,6 +1178,233 @@ namespace Aardvark.Geometry.Tests
 
         #endregion
 
+        #region QueryGridXY
+
+        [Test]
+        public void QueryGridXY_AssignsBoundaryPointsExactlyOnce()
+        {
+            var fixture = CreateGridQueryFixture();
+            var stride = new V2d(1.0, 0.5);
+            var expected = fixture.Positions;
+
+            var pointSetOwners = AssertGridQuery(
+                fixture.PointSet.QueryGridXY(stride), stride, expected, fixture, checkNormals: true
+                );
+            var inMemoryOwners = AssertGridQuery(
+                fixture.PointSet.Root.Value.QueryGridXY(stride, maxInMemoryPointCount: int.MaxValue),
+                stride, expected, fixture, checkNormals: true
+                );
+            var outOfCoreOwners = AssertGridQuery(
+                fixture.PointSet.Root.Value.QueryGridXY(stride, maxInMemoryPointCount: 0),
+                stride, expected, fixture, checkNormals: true
+                );
+
+            AssertOwnerMapsEqual(pointSetOwners, inMemoryOwners);
+            AssertOwnerMapsEqual(pointSetOwners, outOfCoreOwners);
+        }
+
+        [Test]
+        public void QueryGridXY_RespectsMinCellExponent()
+        {
+            var fixture = CreateGridQueryFixture();
+            var root = fixture.PointSet.Root.Value;
+            var minCellExponent = root.Cell.Exponent;
+            var stride = new V2d(1.0, 0.5);
+            var front = root.QueryAllPoints(minCellExponent)
+                .SelectMany(chunk => chunk.Positions)
+                .ToArray();
+
+            ClassicAssert.IsTrue(front.Length > 0);
+            ClassicAssert.Less(front.Length, fixture.Positions.Length);
+
+            var pointSetOwners = AssertGridQuery(
+                fixture.PointSet.QueryGridXY(stride, minCellExponent),
+                stride, front, fixture, checkNormals: false
+                );
+            var inMemoryOwners = AssertGridQuery(
+                root.QueryGridXY(stride, maxInMemoryPointCount: int.MaxValue, minCellExponent: minCellExponent),
+                stride, front, fixture, checkNormals: false
+                );
+            var outOfCoreOwners = AssertGridQuery(
+                root.QueryGridXY(stride, maxInMemoryPointCount: 0, minCellExponent: minCellExponent),
+                stride, front, fixture, checkNormals: false
+                );
+
+            AssertOwnerMapsEqual(pointSetOwners, inMemoryOwners);
+            AssertOwnerMapsEqual(pointSetOwners, outOfCoreOwners);
+        }
+
+        private sealed class GridQueryFixture
+        {
+            public PointSet PointSet { get; }
+            public V3d[] Positions { get; }
+            public C4b[] Colors { get; }
+            public V3f[] Normals { get; }
+            public int[] Intensities { get; }
+            public byte[] Classifications { get; }
+            public int[] PartIndices { get; }
+
+            public GridQueryFixture(
+                PointSet pointSet,
+                V3d[] positions,
+                C4b[] colors,
+                V3f[] normals,
+                int[] intensities,
+                byte[] classifications,
+                int[] partIndices
+                )
+            {
+                PointSet = pointSet;
+                Positions = positions;
+                Colors = colors;
+                Normals = normals;
+                Intensities = intensities;
+                Classifications = classifications;
+                PartIndices = partIndices;
+            }
+        }
+
+        private static GridQueryFixture CreateGridQueryFixture()
+        {
+            var positions = new[]
+            {
+                new V3d(-2.0, -2.0, 0.00),
+                new V3d(-1.0, -1.0, 0.01),
+                new V3d(-1.0,  0.0, 0.02),
+                new V3d( 0.0, -1.0, 0.03),
+                new V3d( 0.0,  0.0, 0.04),
+                new V3d( 1.0,  0.0, 0.05),
+                new V3d( 0.0,  1.0, 0.06),
+                new V3d( 1.0,  1.0, 0.07),
+                new V3d( 2.0,  2.0, 0.08),
+                new V3d(-0.25, -0.25, 0.09),
+                new V3d( 0.25,  0.25, 0.10),
+                new V3d( 0.999, -1.001, 0.11),
+                new V3d(-1.001,  0.999, 0.12),
+                new V3d( 1.0, -1.0, 0.13),
+                new V3d(-1.0,  1.0, 0.14),
+                new V3d( 2.0, -2.0, 0.15)
+            };
+            var colors = new C4b[positions.Length].SetByIndex(i =>
+                new C4b((byte)(i + 1), (byte)(i + 17), (byte)(i + 33), (byte)255)
+                );
+            var normals = new V3f[positions.Length].SetByIndex(i => new V3f(i + 1, i + 2, i + 3).Normalized);
+            var intensities = new int[positions.Length].SetByIndex(i => 1000 + i);
+            var classifications = new byte[positions.Length].SetByIndex(i => (byte)(50 + i));
+            var partIndices = new int[positions.Length].SetByIndex(i => 200 + i);
+            var chunk = new Chunk(
+                positions,
+                colors,
+                normals,
+                intensities,
+                classifications,
+                partIndices,
+                partIndexRange: null,
+                bbox: null
+                );
+            var config = ImportConfig.Default
+                .WithStorage(PointCloud.CreateInMemoryStore(cache: default))
+                .WithKey("query-grid-xy")
+                .WithOctreeSplitLimit(2);
+            var pointSet = PointCloud.Chunks(chunk, config);
+            var storedPositions = new V3d[positions.Length];
+            foreach (var storedChunk in pointSet.QueryAllPoints())
+            {
+                for (var i = 0; i < storedChunk.Count; i++)
+                {
+                    storedPositions[storedChunk.Intensities[i] - 1000] = storedChunk.Positions[i];
+                }
+            }
+            return new GridQueryFixture(
+                pointSet, storedPositions, colors, normals, intensities, classifications, partIndices
+                );
+        }
+
+        private static Dictionary<V3d, Box2d> AssertGridQuery(
+            IEnumerable<Queries.GridQueryBox2dResult> results,
+            V2d stride,
+            V3d[] expectedPositions,
+            GridQueryFixture fixture,
+            bool checkNormals
+            )
+        {
+            var expected = expectedPositions.ToHashSet();
+            var sourceIndices = fixture.Positions
+                .Select((position, index) => (key: PositionKey(position), index))
+                .ToDictionary(pair => pair.key, pair => pair.index);
+            var owners = new Dictionary<V3d, Box2d>();
+            var footprints = new HashSet<Box2d>();
+
+            foreach (var result in results)
+            {
+                var footprint = result.Footprint;
+                ClassicAssert.IsTrue(footprints.Add(footprint));
+                ClassicAssert.AreEqual(footprint.Min + stride, footprint.Max);
+                var resultPointCount = 0;
+
+                foreach (var chunk in result.Points)
+                {
+                    resultPointCount += chunk.Count;
+                    ClassicAssert.IsTrue(chunk.Count > 0);
+                    ClassicAssert.AreEqual(chunk.Count, chunk.Colors?.Count);
+                    ClassicAssert.AreEqual(chunk.Count, chunk.Normals?.Count);
+                    ClassicAssert.AreEqual(chunk.Count, chunk.Intensities?.Count);
+                    ClassicAssert.AreEqual(chunk.Count, chunk.Classifications?.Count);
+                    var partIndices = chunk.TryGetPartIndices();
+                    ClassicAssert.IsNotNull(partIndices);
+                    ClassicAssert.AreEqual(chunk.Count, partIndices.Count);
+
+                    for (var i = 0; i < chunk.Count; i++)
+                    {
+                        var position = chunk.Positions[i];
+                        ClassicAssert.IsTrue(expected.Contains(position));
+                        ClassicAssert.IsTrue(position.X >= footprint.Min.X && position.X < footprint.Max.X);
+                        ClassicAssert.IsTrue(position.Y >= footprint.Min.Y && position.Y < footprint.Max.Y);
+                        ClassicAssert.IsTrue(owners.TryAdd(position, footprint));
+
+                        var expectedMin = new V2d(
+                            Math.Floor(position.X / stride.X) * stride.X,
+                            Math.Floor(position.Y / stride.Y) * stride.Y
+                            );
+                        ClassicAssert.AreEqual(expectedMin, footprint.Min);
+
+                        var sourceIndex = sourceIndices[PositionKey(position)];
+                        ClassicAssert.AreEqual(fixture.Colors[sourceIndex], chunk.Colors[i]);
+                        if (checkNormals) ClassicAssert.AreEqual(fixture.Normals[sourceIndex], chunk.Normals[i]);
+                        ClassicAssert.AreEqual(fixture.Intensities[sourceIndex], chunk.Intensities[i]);
+                        ClassicAssert.AreEqual(fixture.Classifications[sourceIndex], chunk.Classifications[i]);
+                        ClassicAssert.AreEqual(fixture.PartIndices[sourceIndex], partIndices[i]);
+                    }
+                }
+
+                ClassicAssert.Greater(resultPointCount, 0, $"Empty grid result for {footprint}.");
+            }
+
+            ClassicAssert.AreEqual(expected.Count, owners.Count);
+            ClassicAssert.IsTrue(expected.SetEquals(owners.Keys));
+            return owners;
+        }
+
+        private static V2l PositionKey(V3d position)
+            => new(
+                (long)Math.Round(position.X * 1000.0),
+                (long)Math.Round(position.Y * 1000.0)
+                );
+
+        private static void AssertOwnerMapsEqual(
+            IReadOnlyDictionary<V3d, Box2d> expected,
+            IReadOnlyDictionary<V3d, Box2d> actual
+            )
+        {
+            ClassicAssert.AreEqual(expected.Count, actual.Count);
+            foreach (var pair in expected)
+            {
+                ClassicAssert.IsTrue(actual.TryGetValue(pair.Key, out var footprint));
+                ClassicAssert.AreEqual(pair.Value, footprint);
+            }
+        }
+
+        #endregion
 
         [Test]
         public void CanQueryPointsWithAttributes()

--- a/src/Aardvark.Geometry.PointSet/Queries/QueriesGrid.cs
+++ b/src/Aardvark.Geometry.PointSet/Queries/QueriesGrid.cs
@@ -17,8 +17,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-#pragma warning disable CS9113 // Parameter is unread.
-
 namespace Aardvark.Geometry.Points;
 
 /// <summary>
@@ -178,128 +176,41 @@ public static partial class Queries
         }
     }
 
-    //public class GridQueryResult
-    //{
-    //    /// <summary>Grid cell bounding box.</summary>
-    //    public Cell2d Footprint { get; }
-
-    //    /// <summary>Total number of points in grid cell.</summary>
-    //    public long Count { get; }
-
-    //    /// <summary>All points in cell.</summary>
-    //    public Chunk[] Points { get; }
-
-    //    public GridQueryResult(Cell2d footprint, IEnumerable<Chunk> points)
-    //    {
-    //        Footprint = footprint;
-    //        Points = points;
-    //    }
-    //}
-
-    ///// <summary>
-    ///// </summary>
-    //public static IEnumerable<GridQueryResult> QueryGridXY(
-    //    this PointSet self, int stride, int minCellExponent = int.MinValue
-    //    )
-    //    => QueryGridXY(self.Root.Value, stride, minCellExponent);
-
-    ///// <summary>
-    ///// </summary>
-    //public static IEnumerable<GridQueryResult> QueryGridXY(
-    //    this IPointCloudNode self, int stride, int minCellExponent = int.MinValue
-    //    )
-    //{
-    //    var bbw = self.BoundingBoxExactGlobal;  // bounding box (world space)
-    //    var bbt = new Box2l(                    // bounding box (tile space)
-    //        new V2l((long)Math.Floor(bbw.Min.X / stride.X), (long)Math.Floor(bbw.Min.Y / stride.Y)),
-    //        new V2l((long)Math.Floor(bbw.Max.X / stride.X) + 1L, (long)Math.Floor(bbw.Max.Y / stride.Y) + 1L)
-    //        );
-
-    //    return QueryRecGridXY(bbt, stride, minCellExponent, new List<IPointCloudNode> { self });
-    //}
-
-    //private static IEnumerable<GridQueryResult> QueryRecGridXY(Box2l bb, int stride, int minCellExponent, List<IPointCloudNode> roots)
-    //{
-    //    var area = bb.Area;
-    //    if (area == 0 || roots.Count == 0) yield break;
-
-    //    var q = new Box2d(bb.Min.X * stride.X, bb.Min.Y * stride.Y, bb.Max.X * stride.X, bb.Max.Y * stride.Y);
-
-    //    if (area == 1)
-    //    {
-    //        yield return new GridQueryBox2dResult(q, roots.SelectMany(root => root.QueryPointsInsideBoxXY(q)));
-    //    }
-    //    else
-    //    {
-    //        var newRoots = new List<IPointCloudNode>();
-    //        foreach (var r in roots)
-    //        {
-    //            if (r.IsLeaf) newRoots.Add(r);
-    //            else
-    //            {
-    //                var _bb = r.BoundingBoxExactGlobal.XY;
-    //                if (!q.Intersects(_bb)) { }
-    //                else if (q.Contains(_bb)) newRoots.Add(r);
-    //                else
-    //                {
-    //                    var sub = r.Subnodes;
-    //                    void add(int i) { if (sub[i] != null) { newRoots.Add(sub[i].Value); } }
-    //                    var c = r.Center.XY;
-    //                    if (q.Max.X < c.X)
-    //                    {
-    //                        // left cells
-    //                        if (q.Max.Y < c.Y) { add(0); add(4); } // left/bottom
-    //                        else if (q.Min.Y >= c.Y) { add(2); add(6); } // left/top
-    //                        else { add(0); add(4); add(2); add(6); }
-    //                    }
-    //                    else if (q.Min.X >= c.X)
-    //                    {
-    //                        // right cells
-    //                        if (q.Max.Y < c.Y) { add(1); add(5); } // right/bottom
-    //                        else if (q.Min.Y >= c.Y) { add(3); add(7); } // right/top
-    //                        else { add(1); add(5); add(3); add(7); }
-    //                    }
-    //                    else
-    //                    {
-    //                        // left/right cells
-    //                        if (q.Max.Y < c.Y) { add(0); add(1); add(4); add(5); } // bottom
-    //                        else if (q.Min.Y >= c.Y) { add(2); add(3); add(6); add(7); } // top
-    //                        else { newRoots.Add(r); }
-    //                    }
-    //                }
-    //            }
-    //        }
-
-    //        var sbbs = bb.SplitAtCenter();
-    //        foreach (var sbb in sbbs)
-    //        {
-    //            if (sbb.Min.X == sbb.Max.X || sbb.Min.Y == sbb.Max.Y) continue;
-    //            var xs = QueryRecGridXY(sbb, stride, minCellExponent, newRoots);
-    //            foreach (var x in xs) yield return x;
-    //        }
-    //    }
-    //}
-
     #endregion
 
     #region grid query (arbitrary stride)
 
     /// <summary>
+    /// Result for one half-open grid cell.
     /// </summary>
-    /// <param name="Footprint">Grid cell bounding box.</param>
-    /// <param name="Points"></param>
-    public class GridQueryBox2dResult(Box2d Footprint, IEnumerable<Chunk> Points)
+    public class GridQueryBox2dResult
     {
+        /// <summary>Grid cell bounding box. Points on Min are included; points on Max are excluded.</summary>
+        public Box2d Footprint { get; }
+
+        /// <summary>Points in this grid cell.</summary>
+        public IEnumerable<Chunk> Points { get; }
+
+        /// <summary>
+        /// Creates a result for one grid cell.
+        /// </summary>
+        public GridQueryBox2dResult(Box2d footprint, IEnumerable<Chunk> points)
+        {
+            Footprint = footprint;
+            Points = points;
+        }
     }
 
     /// <summary>
+    /// Lazily partitions points into half-open grid cells [Min, Max).
     /// </summary>
     public static IEnumerable<GridQueryBox2dResult> QueryGridXY(
         this PointSet self, V2d stride, int minCellExponent = int.MinValue
         )
-        => QueryGridXY(self.Root.Value, stride, minCellExponent);
+        => QueryGridXY(self.Root.Value, stride, minCellExponent: minCellExponent);
 
     /// <summary>
+    /// Lazily partitions points into half-open grid cells [Min, Max).
     /// </summary>
     public static IEnumerable<GridQueryBox2dResult> QueryGridXY(
         this IPointCloudNode self, V2d stride, int maxInMemoryPointCount = 10 * 1024 * 1024, int minCellExponent = int.MinValue
@@ -309,7 +220,7 @@ public static partial class Queries
         var bbt = new Box2l(                    // bounding box (tile space)
             new V2l((long)Math.Floor(bbw.Min.X / stride.X), (long)Math.Floor(bbw.Min.Y / stride.Y)),
             new V2l((long)Math.Floor(bbw.Max.X / stride.X) + 1L, (long)Math.Floor(bbw.Max.Y / stride.Y) + 1L)
-            ) ;
+            );
 
         return QueryGridRecXY(bbt, stride, maxInMemoryPointCount, minCellExponent, [self]);
     }
@@ -319,8 +230,7 @@ public static partial class Queries
         var area = bb.Area;
         if (area == 0 || chunk.Count == 0) yield break;
 
-        var q = new Box2d(bb.Min.X * stride.X, bb.Min.Y * stride.Y, bb.Max.X * stride.X, bb.Max.Y * stride.Y);
-
+        var q = GetGridBounds(bb, stride);
         var newChunk = chunk.ImmutableFilterByBoxXY(q);
         if (newChunk.Count == 0) yield break;
 
@@ -330,8 +240,7 @@ public static partial class Queries
         }
         else
         {
-            var sbbs = bb.SplitAtCenter();
-            foreach (var sbb in sbbs)
+            foreach (var sbb in bb.SplitAtCenter())
             {
                 if (sbb.Min.X == sbb.Max.X || sbb.Min.Y == sbb.Max.Y) continue;
                 var xs = QueryGridRecInMemoryXY(sbb, stride, newChunk);
@@ -339,81 +248,194 @@ public static partial class Queries
             }
         }
     }
-    private static IEnumerable<GridQueryBox2dResult> QueryGridRecXY(Box2l bb, V2d stride, int maxInMemoryPointCount, int minCellExponent, List<IPointCloudNode> roots)
+
+    private static IEnumerable<GridQueryBox2dResult> QueryGridRecXY(
+        Box2l bb,
+        V2d stride,
+        int maxInMemoryPointCount,
+        int minCellExponent,
+        List<IPointCloudNode> roots
+        )
     {
         var area = bb.Area;
         if (area == 0 || roots.Count == 0) yield break;
 
-        var q = new Box2d(bb.Min.X * stride.X, bb.Min.Y * stride.Y, bb.Max.X * stride.X, bb.Max.Y * stride.Y);
-
+        var q = GetGridBounds(bb, stride);
         if (area == 1)
         {
-            yield return new GridQueryBox2dResult(q, roots.SelectMany(root => root.QueryPointsInsideBoxXY(q)));
+            if (ContainsPointsInsideHalfOpenBoxXY(roots, q, minCellExponent))
+            {
+                var points = QueryPointsInsideHalfOpenBoxXY(roots, q, minCellExponent);
+                yield return new GridQueryBox2dResult(q, points);
+            }
+            yield break;
+        }
+
+        var newRoots = new List<IPointCloudNode>();
+        foreach (var root in roots)
+        {
+            CollectIntersectingNodes(root, q, minCellExponent, newRoots);
+        }
+        if (newRoots.Count == 0) yield break;
+
+        var sbbs = bb.SplitAtCenter();
+        var total = newRoots.Sum(root => root.PointCountTree);
+        if (total <= maxInMemoryPointCount)
+        {
+            var chunk = Chunk.ImmutableMerge(
+                QueryPointsInsideHalfOpenBoxXY(newRoots, q, minCellExponent)
+                );
+            foreach (var sbb in sbbs)
+            {
+                if (sbb.Min.X == sbb.Max.X || sbb.Min.Y == sbb.Max.Y) continue;
+                var xs = QueryGridRecInMemoryXY(sbb, stride, chunk);
+                foreach (var x in xs) yield return x;
+            }
         }
         else
         {
-            var newRoots = new List<IPointCloudNode>();
-            foreach (var r in roots)
+            foreach (var sbb in sbbs)
             {
-                if (r.IsLeaf) newRoots.Add(r);
-                else
-                {
-                    var _bb = r.BoundingBoxExactGlobal.XY;
-                    if (!q.Intersects(_bb)) { }
-                    else if (q.Contains(_bb)) newRoots.Add(r);
-                    else
-                    {
-                        var sub = r.Subnodes!;
-                        void add(int i) { if (sub[i] != null) { newRoots.Add(sub[i]!.Value); } }
-                        var c = r.Center.XY;
-                        if (q.Max.X < c.X)
-                        {
-                            // left cells
-                            if (q.Max.Y < c.Y) { add(0); add(4); } // left/bottom
-                            else if (q.Min.Y >= c.Y) { add(2); add(6); } // left/top
-                            else { add(0); add(4); add(2); add(6); }
-                        }
-                        else if (q.Min.X >= c.X)
-                        {
-                            // right cells
-                            if (q.Max.Y < c.Y) { add(1); add(5); } // right/bottom
-                            else if (q.Min.Y >= c.Y) { add(3); add(7); } // right/top
-                            else { add(1); add(5); add(3); add(7); }
-                        }
-                        else
-                        {
-                            // left/right cells
-                            if (q.Max.Y < c.Y) { add(0); add(1); add(4); add(5); } // bottom
-                            else if (q.Min.Y >= c.Y) { add(2); add(3); add(6); add(7); } // top
-                            else { newRoots.Add(r); }
-                        }
-                    }
-                }
-            }
-
-            var sbbs = bb.SplitAtCenter();
-            var total = newRoots.Sum(r => r.PointCountTree);
-            if (total <= maxInMemoryPointCount)
-            {
-                var chunk = Chunk.ImmutableMerge(newRoots.SelectMany(r => r.QueryPointsInsideBoxXY(q)));
-                foreach (var sbb in sbbs)
-                {
-                    if (sbb.Min.X == sbb.Max.X || sbb.Min.Y == sbb.Max.Y) continue;
-                    var xs = QueryGridRecInMemoryXY(sbb, stride, chunk);
-                    foreach (var x in xs) yield return x;
-                }
-            }
-            else
-            {
-                foreach (var sbb in sbbs)
-                {
-                    if (sbb.Min.X == sbb.Max.X || sbb.Min.Y == sbb.Max.Y) continue;
-                    var xs = QueryGridRecXY(sbb, stride, maxInMemoryPointCount, minCellExponent, newRoots);
-                    foreach (var x in xs) yield return x;
-                }
+                if (sbb.Min.X == sbb.Max.X || sbb.Min.Y == sbb.Max.Y) continue;
+                var xs = QueryGridRecXY(sbb, stride, maxInMemoryPointCount, minCellExponent, newRoots);
+                foreach (var x in xs) yield return x;
             }
         }
     }
+
+    private static void CollectIntersectingNodes(
+        IPointCloudNode node,
+        Box2d query,
+        int minCellExponent,
+        List<IPointCloudNode> result
+        )
+    {
+        if (node.Cell.Exponent < minCellExponent) return;
+
+        var bounds = node.BoundingBoxExactGlobal.XY;
+        if (!IntersectsHalfOpen(query, bounds)) return;
+
+        if (ContainsHalfOpen(query, bounds) || node.IsLeaf || node.Cell.Exponent == minCellExponent)
+        {
+            result.Add(node);
+            return;
+        }
+
+        foreach (var subnode in node.Subnodes!)
+        {
+            if (subnode == null) continue;
+            var child = subnode.Value;
+            if (child.Cell.Exponent >= minCellExponent &&
+                IntersectsHalfOpen(query, child.BoundingBoxExactGlobal.XY))
+            {
+                result.Add(child);
+            }
+        }
+    }
+
+    private static bool ContainsPointsInsideHalfOpenBoxXY(
+        List<IPointCloudNode> roots,
+        Box2d query,
+        int minCellExponent
+        )
+    {
+        var stack = new Stack<(IPointCloudNode Node, bool FullyInside)>(roots.Count);
+        for (var i = roots.Count - 1; i >= 0; i--) stack.Push((roots[i], false));
+
+        while (stack.Count > 0)
+        {
+            var entry = stack.Pop();
+            var node = entry.Node;
+            if (node.Cell.Exponent < minCellExponent) continue;
+
+            var fullyInside = entry.FullyInside;
+            if (!fullyInside)
+            {
+                var bounds = node.BoundingBoxExactGlobal.XY;
+                if (!IntersectsHalfOpen(query, bounds)) continue;
+                fullyInside = ContainsHalfOpen(query, bounds);
+            }
+
+            if (node.IsLeaf || node.Cell.Exponent == minCellExponent)
+            {
+                if (fullyInside && node.PointCountCell > 0) return true;
+                foreach (var position in node.PositionsAbsolute)
+                {
+                    if (ContainsHalfOpen(query, position.XY)) return true;
+                }
+                continue;
+            }
+
+            var subnodes = node.Subnodes!;
+            for (var i = subnodes.Length - 1; i >= 0; i--)
+            {
+                var subnode = subnodes[i];
+                if (subnode != null) stack.Push((subnode.Value, fullyInside));
+            }
+        }
+
+        return false;
+    }
+
+    private static IEnumerable<Chunk> QueryPointsInsideHalfOpenBoxXY(
+        List<IPointCloudNode> roots,
+        Box2d query,
+        int minCellExponent
+        )
+    {
+        var stack = new Stack<(IPointCloudNode Node, bool FullyInside)>(roots.Count);
+        for (var i = roots.Count - 1; i >= 0; i--) stack.Push((roots[i], false));
+
+        while (stack.Count > 0)
+        {
+            var entry = stack.Pop();
+            var node = entry.Node;
+            if (node.Cell.Exponent < minCellExponent) continue;
+
+            var fullyInside = entry.FullyInside;
+            if (!fullyInside)
+            {
+                var bounds = node.BoundingBoxExactGlobal.XY;
+                if (!IntersectsHalfOpen(query, bounds)) continue;
+                fullyInside = ContainsHalfOpen(query, bounds);
+            }
+
+            if (node.IsLeaf || node.Cell.Exponent == minCellExponent)
+            {
+                var chunk = node.ToChunk();
+                if (!fullyInside) chunk = chunk.ImmutableFilterByBoxXY(query);
+                if (chunk.Count > 0) yield return chunk;
+                continue;
+            }
+
+            var subnodes = node.Subnodes!;
+            for (var i = subnodes.Length - 1; i >= 0; i--)
+            {
+                var subnode = subnodes[i];
+                if (subnode != null) stack.Push((subnode.Value, fullyInside));
+            }
+        }
+    }
+
+    private static Box2d GetGridBounds(Box2l bounds, V2d stride)
+        => new(
+            bounds.Min.X * stride.X,
+            bounds.Min.Y * stride.Y,
+            bounds.Max.X * stride.X,
+            bounds.Max.Y * stride.Y
+            );
+
+    private static bool IntersectsHalfOpen(Box2d query, Box2d bounds)
+        => bounds.Max.X >= query.Min.X && bounds.Min.X < query.Max.X &&
+           bounds.Max.Y >= query.Min.Y && bounds.Min.Y < query.Max.Y;
+
+    private static bool ContainsHalfOpen(Box2d query, Box2d bounds)
+        => bounds.Min.X >= query.Min.X && bounds.Max.X < query.Max.X &&
+           bounds.Min.Y >= query.Min.Y && bounds.Max.Y < query.Max.Y;
+
+    private static bool ContainsHalfOpen(Box2d query, V2d point)
+        => point.X >= query.Min.X && point.X < query.Max.X &&
+           point.Y >= query.Min.Y && point.Y < query.Max.Y;
 
     #endregion
 }


### PR DESCRIPTION
## Summary
- restore public immutable `Footprint` and `Points` result properties
- forward `minCellExponent` correctly from `PointSet` and honor it in collection, materialization, and terminal filtering
- assign every point to one half-open `[Min, Max)` tile using floor-derived ownership
- use exact node bounds plus terminal position filtering in both threshold paths while preserving all standard attributes and part indices
- remove the obsolete commented grid implementation and document LoD, ownership, laziness, and memory-threshold behavior

## Performance
Warmed, fully consumed 32³-point queries produced identical 64-tile / 32,768-point checksums before and after:

| Path | Before | After | Allocations before | Allocations after |
| --- | ---: | ---: | ---: | ---: |
| In-memory cutoff | 7.79–8.09 ms | 7.54–7.91 ms | 9,207,116 B | 8,753,618 B |
| Forced out-of-core | 3.50–3.95 ms | 3.47–3.54 ms | 4,069,624 B | 3,424,128 B |

The corrected paths show no throughput regression and reduce allocations by 4.9% and 15.9%, respectively.

## Validation
- focused query tests: 74 passed
- complete Release suite: 444 passed, 2 existing skips
- complete Release solution build with warnings as errors: 0 warnings, 0 errors

Fixes #49.