### PR TITLE
Fix GenericChunk L1 minimum-distance filtering

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,5 @@
+- [Points] fixed `GenericChunk` sequential L1 filtering to use exact, unsquared minimum-distance thresholds (#51)
+
 ### 5.6.3
 - Updated SharpCompress to 0.48.1 to address CVE-2026-44788
 

--- a/ai/IMPORTERS.md
+++ b/ai/IMPORTERS.md
@@ -44,6 +44,8 @@ var config = ImportConfig.Default
 var pointset = PointCloud.Import(filename, config);
 ```
 
+`WithMinDist` accepts an exact, unsquared distance in the point cloud's coordinate units. By default, import filtering retains the first point and then skips each point whose Manhattan (L1) distance from the previous retained point is strictly less than `MinDist`; points exactly at the threshold are retained. Enabling `WithNormalizePointDensityGlobal(true)` instead selects one point per global density cell derived from the same unsquared value.
+
 ### Low-Level Chunk Access
 
 Each importer exposes a `Chunks()` method for direct chunk iteration:

--- a/src/Aardvark.Algodat.Tests/GenericChunkTests.cs
+++ b/src/Aardvark.Algodat.Tests/GenericChunkTests.cs
@@ -1,0 +1,168 @@
+﻿/*
+    Copyright (C) 2006-2026. Aardvark Platform Team. http://github.com/aardvark-platform.
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+using Aardvark.Base;
+using Aardvark.Data;
+using Aardvark.Data.Points;
+using Aardvark.Geometry.Points;
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace Aardvark.Geometry.Tests
+{
+    [TestFixture]
+    public class GenericChunkTests
+    {
+        [TestCase(0.5)]
+        [TestCase(2.0)]
+        public void ImmutableFilterSequentialMinDistL1UsesUnsquaredThreshold(double minDist)
+        {
+            var coordinates = minDist < 1.0
+                ? new[] { 0.0, 0.25, 0.5, 1.0 }
+                : new[] { 0.0, 1.5, 3.0, 4.5, 6.0 };
+            var expectedIndices = minDist < 1.0
+                ? new[] { 0, 2, 3 }
+                : new[] { 0, 2, 4 };
+
+            AssertSequentialFilter(
+                coordinates.Select(x => new V2f((float)x, 0.0f)).ToArray(),
+                GenericChunk.Defs.Positions2f,
+                p => (V3d)p.XYO,
+                minDist,
+                expectedIndices
+                );
+            AssertSequentialFilter(
+                coordinates.Select(x => new V2d(x, 0.0)).ToArray(),
+                GenericChunk.Defs.Positions2d,
+                p => p.XYO,
+                minDist,
+                expectedIndices
+                );
+            AssertSequentialFilter(
+                coordinates.Select(x => new V3f((float)x, 0.0f, 0.0f)).ToArray(),
+                GenericChunk.Defs.Positions3f,
+                p => (V3d)p,
+                minDist,
+                expectedIndices
+                );
+            AssertSequentialFilter(
+                coordinates.Select(x => new V3d(x, 0.0, 0.0)).ToArray(),
+                GenericChunk.Defs.Positions3d,
+                p => p,
+                minDist,
+                expectedIndices
+                );
+        }
+
+        [Test]
+        public void GenericChunkImportUsesUnsquaredNonGlobalMinDist()
+        {
+            var positions = new[]
+            {
+                new V3d(0.0, 0.0, 0.0),
+                new V3d(0.25, 0.0, 0.0),
+                new V3d(0.5, 0.0, 0.0),
+                new V3d(1.0, 0.0, 0.0)
+            };
+            var source = CreateChunk(positions, GenericChunk.Defs.Positions3d);
+            var config = ImportConfig.Default
+                .WithStorage(PointCloud.CreateInMemoryStore(cache: default))
+                .WithKey("generic-chunk-min-dist")
+                .WithOctreeSplitLimit(2)
+                .WithMinDist(0.5)
+                .WithNormalizePointDensityGlobal(false);
+
+            var pointSet = PointCloud.Chunks(source, config);
+            var imported = pointSet.QueryAllPoints()
+                .SelectMany(chunk => Enumerable.Range(0, chunk.Count)
+                    .Select(i => (Position: chunk.Positions[i], Intensity: chunk.Intensities[i])))
+                .OrderBy(x => x.Intensity)
+                .ToArray();
+
+            ClassicAssert.AreEqual(3, pointSet.PointCount);
+            ClassicAssert.IsTrue(imported.Select(x => x.Position).SequenceEqual(new[] { positions[0], positions[2], positions[3] }));
+            ClassicAssert.IsTrue(imported.Select(x => x.Intensity).SequenceEqual(new[] { 100, 102, 103 }));
+            ClassicAssert.AreEqual(new Box3d(positions[0], positions[3]), pointSet.BoundingBox);
+        }
+
+        private static void AssertSequentialFilter<T>(
+            T[] positions,
+            Durable.Def positionsDef,
+            Func<T, V3d> toV3d,
+            double minDist,
+            int[] expectedIndices
+            )
+        {
+            var source = CreateChunk(positions, positionsDef);
+            var filtered = source.ImmutableFilterSequentialMinDistL1(minDist);
+            var expectedPositions = expectedIndices.Select(i => positions[i]).ToArray();
+            var expectedColors = expectedIndices.Select(i => ((C4b[])source.Colors)[i]).ToArray();
+            var expectedNormals = expectedIndices.Select(i => ((V3f[])source.Normals)[i]).ToArray();
+            var expectedIntensities = expectedIndices.Select(i => ((int[])source.Intensities)[i]).ToArray();
+            var expectedClassifications = expectedIndices.Select(i => ((byte[])source.Classifications)[i]).ToArray();
+            var expectedBounds = new Box3d(expectedPositions.Select(toV3d).ToArray());
+
+            ClassicAssert.AreEqual(expectedIndices.Length, filtered.Count);
+            ClassicAssert.AreSame(positionsDef, filtered.PositionsDef);
+            ClassicAssert.IsInstanceOf<T[]>(filtered.Positions);
+            ClassicAssert.IsTrue(((T[])filtered.Positions).SequenceEqual(expectedPositions));
+            ClassicAssert.IsTrue(((C4b[])filtered.Colors).SequenceEqual(expectedColors));
+            ClassicAssert.IsTrue(((V3f[])filtered.Normals).SequenceEqual(expectedNormals));
+            ClassicAssert.IsTrue(((int[])filtered.Intensities).SequenceEqual(expectedIntensities));
+            ClassicAssert.IsTrue(((byte[])filtered.Classifications).SequenceEqual(expectedClassifications));
+            ClassicAssert.AreEqual(expectedBounds, filtered.BoundingBox);
+            ClassicAssert.IsTrue(((T[])source.Positions).SequenceEqual(positions));
+
+            if (positions is V3d[] positions3d)
+            {
+                var chunk = new Chunk(
+                    positions3d,
+                    (C4b[])source.Colors,
+                    (V3f[])source.Normals,
+                    (int[])source.Intensities,
+                    (byte[])source.Classifications,
+                    partIndices: null,
+                    partIndexRange: null,
+                    bbox: null
+                    ).ImmutableFilterSequentialMinDistL1(minDist);
+
+                ClassicAssert.IsTrue(chunk.Positions.SequenceEqual(filtered.PositionsAsV3d));
+                ClassicAssert.IsTrue(chunk.Colors.SequenceEqual((C4b[])filtered.Colors));
+                ClassicAssert.IsTrue(chunk.Normals.SequenceEqual((V3f[])filtered.Normals));
+                ClassicAssert.IsTrue(chunk.Intensities.SequenceEqual((int[])filtered.Intensities));
+                ClassicAssert.IsTrue(chunk.Classifications.SequenceEqual((byte[])filtered.Classifications));
+                ClassicAssert.AreEqual(chunk.BoundingBox, filtered.BoundingBox);
+            }
+        }
+
+        private static GenericChunk CreateChunk<T>(T[] positions, Durable.Def positionsDef)
+        {
+            var colors = new C4b[positions.Length].SetByIndex(i =>
+                new C4b((byte)(i + 1), (byte)(i + 11), (byte)(i + 21), byte.MaxValue)
+                );
+            var normals = new V3f[positions.Length].SetByIndex(i => new V3f(i + 1, i + 2, i + 3));
+            var intensities = new int[positions.Length].SetByIndex(i => 100 + i);
+            var classifications = new byte[positions.Length].SetByIndex(i => (byte)(20 + i));
+            var data = ImmutableDictionary<Durable.Def, object>.Empty
+                .Add(positionsDef, positions)
+                .Add(GenericChunk.Defs.Colors4b, colors)
+                .Add(GenericChunk.Defs.Normals3f, normals)
+                .Add(GenericChunk.Defs.Intensities1i, intensities)
+                .Add(GenericChunk.Defs.Classifications1b, classifications);
+            return new GenericChunk(data);
+        }
+    }
+}

--- a/src/Aardvark.Data.Points.Base/Chunk.cs
+++ b/src/Aardvark.Data.Points.Base/Chunk.cs
@@ -552,7 +552,7 @@ namespace Aardvark.Data.Points
         }
 
         /// <summary>
-        /// Removes points which are less than minDist from previous point (L2, Euclidean).
+        /// Removes points whose Euclidean distance from the previous retained point is less than the exact, unsquared <paramref name="minDist"/>.
         /// </summary>
         public Chunk ImmutableFilterSequentialMinDistL2(double minDist)
         {
@@ -584,7 +584,7 @@ namespace Aardvark.Data.Points
         }
 
         /// <summary>
-        /// Removes points which are less than minDist from previous point (L1, Manhattan).
+        /// Removes points whose Manhattan distance from the previous retained point is less than the exact, unsquared <paramref name="minDist"/>.
         /// </summary>
         public Chunk ImmutableFilterSequentialMinDistL1(double minDist)
         {
@@ -615,7 +615,7 @@ namespace Aardvark.Data.Points
         }
 
         /// <summary>
-        /// Returns chunk with duplicate point positions removed.
+        /// Keeps the first point in input order for each terminal density cell. The cell level is selected from the exact, unsquared <see cref="ParseConfig.MinDist"/>.
         /// </summary>
         public Chunk ImmutableFilterMinDistByCell(Cell bounds, ParseConfig config)
         {

--- a/src/Aardvark.Data.Points.Base/GenericChunk.cs
+++ b/src/Aardvark.Data.Points.Base/GenericChunk.cs
@@ -688,7 +688,7 @@ namespace Aardvark.Data.Points
         }
 
         /// <summary>
-        /// Removes points which are less than minDist from previous point (L2, Euclidean).
+        /// Removes points whose Euclidean distance from the previous retained point is less than the exact, unsquared <paramref name="minDist"/>.
         /// </summary>
         public GenericChunk ImmutableFilterSequentialMinDistL2(double minDist)
         {
@@ -801,12 +801,11 @@ namespace Aardvark.Data.Points
         }
 
         /// <summary>
-        /// Removes points which are less than minDist from previous point (L1, Manhattan).
+        /// Removes points whose Manhattan distance from the previous retained point is less than the exact, unsquared <paramref name="minDist"/>.
         /// </summary>
         public GenericChunk ImmutableFilterSequentialMinDistL1(double minDist)
         {
             if (minDist <= 0.0 || Count <= 1) return this;
-            var minDistSquared = minDist * minDist;
 
             switch (Data[PositionsDef])
             {
@@ -817,7 +816,7 @@ namespace Aardvark.Data.Points
                         for (var i = 0; i < ps.Length; i++)
                         {
                             var p = ps[i];
-                            if (Utils.DistLessThanL1(ref p, ref last, minDistSquared)) continue;
+                            if (Utils.DistLessThanL1(ref p, ref last, minDist)) continue;
                             last = p; ia.Add(i);
                         }
                         return Subset(ia);
@@ -829,7 +828,7 @@ namespace Aardvark.Data.Points
                         for (var i = 0; i < ps.Length; i++)
                         {
                             var p = ps[i];
-                            if (Utils.DistLessThanL1(ref p, ref last, minDistSquared)) continue;
+                            if (Utils.DistLessThanL1(ref p, ref last, minDist)) continue;
                             last = p; ia.Add(i);
                         }
                         return Subset(ia);
@@ -841,7 +840,7 @@ namespace Aardvark.Data.Points
                         for (var i = 0; i < ps.Length; i++)
                         {
                             var p = ps[i];
-                            if (Utils.DistLessThanL1(ref p, ref last, minDistSquared)) continue;
+                            if (Utils.DistLessThanL1(ref p, ref last, minDist)) continue;
                             last = p; ia.Add(i);
                         }
                         return Subset(ia);
@@ -853,7 +852,7 @@ namespace Aardvark.Data.Points
                         for (var i = 0; i < ps.Length; i++)
                         {
                             var p = ps[i];
-                            if (Utils.DistLessThanL1(ref p, ref last, minDistSquared)) continue;
+                            if (Utils.DistLessThanL1(ref p, ref last, minDist)) continue;
                             last = p; ia.Add(i);
                         }
                         return Subset(ia);
@@ -866,7 +865,7 @@ namespace Aardvark.Data.Points
                         for (var i = 0; i < ps.Count; i++)
                         {
                             var p = ps[i];
-                            if (Utils.DistLessThanL1(ref p, ref last, minDistSquared)) continue;
+                            if (Utils.DistLessThanL1(ref p, ref last, minDist)) continue;
                             last = p; ia.Add(i);
                         }
                         return Subset(ia);
@@ -878,7 +877,7 @@ namespace Aardvark.Data.Points
                         for (var i = 0; i < ps.Count; i++)
                         {
                             var p = ps[i];
-                            if (Utils.DistLessThanL1(ref p, ref last, minDistSquared)) continue;
+                            if (Utils.DistLessThanL1(ref p, ref last, minDist)) continue;
                             last = p; ia.Add(i);
                         }
                         return Subset(ia);
@@ -890,7 +889,7 @@ namespace Aardvark.Data.Points
                         for (var i = 0; i < ps.Count; i++)
                         {
                             var p = ps[i];
-                            if (Utils.DistLessThanL1(ref p, ref last, minDistSquared)) continue;
+                            if (Utils.DistLessThanL1(ref p, ref last, minDist)) continue;
                             last = p; ia.Add(i);
                         }
                         return Subset(ia);
@@ -902,7 +901,7 @@ namespace Aardvark.Data.Points
                         for (var i = 0; i < ps.Count; i++)
                         {
                             var p = ps[i];
-                            if (Utils.DistLessThanL1(ref p, ref last, minDistSquared)) continue;
+                            if (Utils.DistLessThanL1(ref p, ref last, minDist)) continue;
                             last = p; ia.Add(i);
                         }
                         return Subset(ia);
@@ -914,7 +913,7 @@ namespace Aardvark.Data.Points
         }
 
         /// <summary>
-        /// Returns chunk with duplicate point positions removed.
+        /// Keeps the first point in input order for each terminal density cell. The cell level is selected from the exact, unsquared <see cref="ParseConfig.MinDist"/>.
         /// </summary>
         public GenericChunk ImmutableFilterMinDistByCell(Cell bounds, ParseConfig config)
         {
@@ -948,7 +947,6 @@ namespace Aardvark.Data.Points
                 if (c.Exponent == smallestCellExponent)
                 {
                     take[ia[0]] = true;
-                    ia.Add(ia[0]);
                     return;
                 }
 

--- a/src/Aardvark.Data.Points.Base/ParseConfig.cs
+++ b/src/Aardvark.Data.Points.Base/ParseConfig.cs
@@ -186,7 +186,8 @@ namespace Aardvark.Data.Points
         public int MaxDegreeOfParallelism;
 
         /// <summary>
-        /// Skip points which are less than given distance from previous point.
+        /// Minimum point-density filtering distance in coordinate units, supplied as an exact, unsquared value.
+        /// Sequential filtering compares the Manhattan distance from the previous retained point and retains points at exactly this distance.
         /// </summary>
         public double MinDist;
 
@@ -276,7 +277,9 @@ namespace Aardvark.Data.Points
         /// <summary></summary>
         public ParseConfig WithMaxDegreeOfParallelism(int v) => new(this) { MaxDegreeOfParallelism = v };
 
-        /// <summary></summary>
+        /// <summary>
+        /// Sets the exact, unsquared minimum distance used for point-density filtering.
+        /// </summary>
         public ParseConfig WithMinDist(double v) => new(this) { MinDist = v };
 
         /// <summary></summary>

--- a/src/Aardvark.Geometry.PointSet/Octrees/ImportConfig.cs
+++ b/src/Aardvark.Geometry.PointSet/Octrees/ImportConfig.cs
@@ -45,7 +45,8 @@ public class ImportConfig
     public int MaxDegreeOfParallelism => ParseConfig.MaxDegreeOfParallelism;
 
     /// <summary>
-    /// Remove points on import with less than this distance to previous point.
+    /// Minimum point-density filtering distance in coordinate units, supplied as an exact, unsquared value.
+    /// Non-global filtering uses Manhattan distance from the previous retained point and retains points at exactly this distance.
     /// </summary>
     public double MinDist => ParseConfig.MinDist;
     /// <summary>
@@ -53,7 +54,7 @@ public class ImportConfig
     /// </summary>
     public int ReadBufferSizeInBytes => ParseConfig.ReadBufferSizeInBytes;
 
-    /// <summary>Normalizes point density globally using MinDist distance.</summary>
+    /// <summary>Uses cell-based global point-density filtering derived from the exact, unsquared <see cref="MinDist"/> value.</summary>
     public bool NormalizePointDensityGlobal { get; private set; } = false;
 
     /// <summary>
@@ -109,10 +110,10 @@ public class ImportConfig
     /// <summary></summary>
     public ImportConfig WithMaxDegreeOfParallelism(int x) => new(this) { ParseConfig = ParseConfig.WithMaxDegreeOfParallelism(x) };
 
-    /// <summary></summary>
+    /// <summary>Sets the exact, unsquared minimum distance used for point-density filtering.</summary>
     public ImportConfig WithMinDist(double x) => new(this) { ParseConfig = ParseConfig.WithMinDist(x) };
 
-    /// <summary></summary>
+    /// <summary>Sets whether point density is normalized globally with cells derived from the exact, unsquared <see cref="MinDist"/> value.</summary>
     public ImportConfig WithNormalizePointDensityGlobal(bool x) => new(this) { NormalizePointDensityGlobal = x };
 
     /// <summary></summary>


### PR DESCRIPTION
## Summary
- pass the exact, unsquared `minDist` to every `GenericChunk` L1 filtering path while leaving L2 behavior unchanged
- remove the unused terminal index-list mutation from cell-based filtering
- cover V2f, V2d, V3f, and V3d thresholds on both sides of one, including order, bounds, attributes, `Chunk` parity, and non-global import behavior
- document exact threshold semantics in the APIs and importer guide

## Performance
Warmed Release benchmarks at `minDist = 1` produced identical checksums before and after:

| Path | Before | After | Allocations before | Allocations after |
| --- | ---: | ---: | ---: | ---: |
| Sequential L1 | 0.34 ms | 0.34 ms | 526,528 B | 526,528 B |
| Cell filtering | 1.24 ms | 1.24 ms | 928,786 B | 814,098 B |

Sequential throughput and allocations are unchanged. Removing the terminal mutation reduces cell-filter allocations by 12.3% without affecting throughput.

## Validation
- focused `GenericChunk` regressions: 3 passed
- focused chunk-filter tests: 20 passed
- complete Release suite: 445 passed, 2 existing skips
- complete Release solution build with warnings as errors: 0 warnings, 0 errors

Fixes #51.