### PR TITLE
Fix intersectable closest-point results

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,5 @@
+- [Intersection] fixed box and triangle closest-point results and kd-tree distance pruning (#53)
+
 ### 5.6.3
 - Updated SharpCompress to 0.48.1 to address CVE-2026-44788
 

--- a/ai/GEOMETRY.md
+++ b/ai/GEOMETRY.md
@@ -96,7 +96,8 @@ Kd-tree–based ray-object intersection with custom object sets.
 |------|---------|
 | `IIntersectableObjectSet` | Interface for ray-intersectable object collections |
 | `KdIntersectionTree` | Kd-tree accelerating ray intersections and closest-point queries |
-| `IntersectableTriangleSet` | Triangle soup implementation of `IIntersectableObjectSet` |
+| `IntersectableBoxSet` | Axis-aligned box implementation of `IIntersectableObjectSet` |
+| `IntersectableTriangleSet` | Indexed or unindexed triangle implementation of `IIntersectableObjectSet` |
 | `ObjectRayHit` | Ray intersection result with t-parameter, point, and object reference |
 | `ObjectClosestPoint` | Closest-point query result with distance and coordinates |
 | `FastRay3d` | Precomputed ray data for efficient kd-tree traversal |
@@ -122,20 +123,30 @@ if (kdTree.Intersect(ray, tmin: 0, tmax: double.MaxValue, ref hit))
 }
 
 // Closest point query
-var closest = new ObjectClosestPoint { DistanceSquared = double.MaxValue };
+var closest = ObjectClosestPoint.MaxRange;
 if (kdTree.ClosestPoint(queryPoint, ref closest))
 {
     V3d nearestPoint = closest.Point;
     double distance = closest.Distance;
+    int objectIndex = closest.SetObject.Index;
 }
+
+// Finite in/out cutoff: initialize both fields consistently.
+var limited = ObjectClosestPoint.MaxRange;
+limited.Distance = 2.0;
+limited.DistanceSquared = 4.0;
+bool foundWithinCutoff = kdTree.ClosestPoint(queryPoint, ref limited);
 ```
+
+Closest-point queries use `DistanceSquared` as a strict incoming cutoff and return `true` only when an accepted candidate is closer. Successful queries set `DistanceSquared`, `Distance`, `Point`, and `SetObject` to the exact nearest result while preserving `Coord` and `ObjectStack`; unsuccessful queries leave the complete result unchanged. `IntersectableBoxSet` and `IntersectableTriangleSet` treat a null object filter as accepting all objects and honor selective object filters. Their point-filter argument remains unused.
 
 ### Gotchas
 
 - **BuildFlags control quality/speed tradeoff** – `FastIntersection` splits at 7 objects, `Raytracing` uses slower build with better quality.
 - **FastRay3d precomputes reciprocals** – Construct once per ray; do not modify direction.
 - **Hit parameter is in/out** – Pass existing hit with `t` limit; updated only if closer intersection found.
-- **Object filters can skip tests** – Supply `null` for no filtering; filters allow skipping objects or hits.
+- **Closest-point cutoff is in/out** – Keep `DistanceSquared` and `Distance` consistent for finite kd-tree cutoffs; candidates at exactly the cutoff are not updates.
+- **Object filters can skip tests** – Supply `null` for no filtering; closest-point point filters are not yet applied by box or triangle sets.
 - **Parallel build enabled by default** – Use `BuildFlags.NoMultithreading` to force single-threaded construction.
 
 ## Aardvark.Geometry.Normals

--- a/src/Aardvark.Algodat.Tests/IntersectableClosestPointTests.cs
+++ b/src/Aardvark.Algodat.Tests/IntersectableClosestPointTests.cs
@@ -1,0 +1,378 @@
+﻿/*
+    Copyright (C) 2006-2026. Aardvark Platform Team. http://github.com/aardvark-platform.
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+using Aardvark.Base;
+using Aardvark.Geometry;
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Aardvark.Geometry.Tests
+{
+    [TestFixture]
+    public class IntersectableClosestPointTests
+    {
+        private static readonly V2d s_preservedCoord = new(7.0, 11.0);
+        private static readonly V3d s_preservedPoint = new(101.0, 102.0, 103.0);
+
+        [Test]
+        public void BoxSetDirectClosestPointHonorsSliceFilterAndCutoff()
+        {
+            var boxes = CreateDirectBoxes();
+            var set = new IntersectableBoxSet(boxes);
+            var objectIndices = new[] { 2, 0, 1, 2 };
+            var stack = new List<SetObject> { new(set, 17) };
+            var closest = InitialResult(set, 100.0, stack);
+            var pointFilterCalls = 0;
+
+            var found = set.ClosestPoint(
+                objectIndices, 1, 2, V3d.Zero,
+                ios_index_objectFilter: null,
+                (_, _, _, _) => { pointFilterCalls++; return true; },
+                ref closest
+                );
+
+            ClassicAssert.IsTrue(found);
+            ClassicAssert.AreEqual(0, pointFilterCalls);
+            AssertClosest(closest, set, 0, new V3d(1.0, 0.0, 0.0), 1.0, stack);
+
+            closest = InitialResult(set, 100.0, stack);
+            found = set.ClosestPoint(
+                objectIndices, 1, 2, V3d.Zero,
+                (_, index) => index == 1,
+                ios_index_part_ocp_pointFilter: null,
+                ref closest
+                );
+
+            ClassicAssert.IsTrue(found);
+            AssertClosest(closest, set, 1, new V3d(8.0, 0.0, 0.0), 64.0, stack);
+
+            closest = InitialResult(set, 0.01, stack);
+            var unchanged = closest;
+            found = set.ClosestPoint(
+                objectIndices, 0, objectIndices.Length, V3d.Zero,
+                ios_index_objectFilter: null,
+                ios_index_part_ocp_pointFilter: null,
+                ref closest
+                );
+
+            ClassicAssert.IsFalse(found);
+            AssertUnchanged(closest, unchanged);
+        }
+
+        [TestCase(false)]
+        [TestCase(true)]
+        public void TriangleSetDirectClosestPointHonorsSliceFilterAndCutoff(bool indexed)
+        {
+            var set = CreateDirectTriangleSet(indexed);
+            var objectIndices = new[] { 2, 0, 1, 2 };
+            var stack = new List<SetObject> { new(set, 19) };
+            var closest = InitialResult(set, 100.0, stack);
+            var pointFilterCalls = 0;
+
+            var found = set.ClosestPoint(
+                objectIndices, 1, 2, V3d.Zero,
+                ios_index_objectFilter: null,
+                (_, _, _, _) => { pointFilterCalls++; return true; },
+                ref closest
+                );
+
+            ClassicAssert.IsTrue(found);
+            ClassicAssert.AreEqual(0, pointFilterCalls);
+            AssertClosest(closest, set, 0, new V3d(1.0, 0.0, 0.0), 1.0, stack);
+
+            closest = InitialResult(set, 100.0, stack);
+            found = set.ClosestPoint(
+                objectIndices, 1, 2, V3d.Zero,
+                (_, index) => index == 1,
+                ios_index_part_ocp_pointFilter: null,
+                ref closest
+                );
+
+            ClassicAssert.IsTrue(found);
+            AssertClosest(closest, set, 1, new V3d(8.0, 0.0, 0.0), 64.0, stack);
+
+            closest = InitialResult(set, 0.01, stack);
+            var unchanged = closest;
+            found = set.ClosestPoint(
+                objectIndices, 0, objectIndices.Length, V3d.Zero,
+                ios_index_objectFilter: null,
+                ios_index_part_ocp_pointFilter: null,
+                ref closest
+                );
+
+            ClassicAssert.IsFalse(found);
+            AssertUnchanged(closest, unchanged);
+        }
+
+        [Test]
+        public void BoxSetKdTreeClosestPointHonorsNullAndSelectiveFilters()
+        {
+            var set = new IntersectableBoxSet(CreateDirectBoxes());
+            var tree = CreateTree(set);
+            var stack = new List<SetObject> { new(set, 23) };
+            var closest = InitialResult(set, 100.0, stack);
+
+            var found = tree.ClosestPoint(V3d.Zero, ref closest);
+
+            ClassicAssert.IsTrue(found);
+            AssertClosest(closest, set, 2, new V3d(0.25, 0.0, 0.0), 0.0625, stack);
+
+            closest = InitialResult(set, 100.0, stack);
+            var pointFilterCalls = 0;
+            found = tree.ClosestPoint(
+                V3d.Zero,
+                (_, index) => index == 1,
+                (_, _, _, _) => { pointFilterCalls++; return true; },
+                ref closest
+                );
+
+            ClassicAssert.IsTrue(found);
+            ClassicAssert.AreEqual(0, pointFilterCalls);
+            AssertClosest(closest, set, 1, new V3d(8.0, 0.0, 0.0), 64.0, stack);
+
+            closest = InitialResult(set, 0.01, stack);
+            var unchanged = closest;
+            found = tree.ClosestPoint(V3d.Zero, ref closest);
+            ClassicAssert.IsFalse(found);
+            AssertUnchanged(closest, unchanged);
+        }
+
+        [TestCase(false)]
+        [TestCase(true)]
+        public void TriangleSetKdTreeClosestPointHonorsNullAndSelectiveFilters(bool indexed)
+        {
+            var set = CreateDirectTriangleSet(indexed);
+            var tree = CreateTree(set);
+            var stack = new List<SetObject> { new(set, 29) };
+            var closest = InitialResult(set, 100.0, stack);
+
+            var found = tree.ClosestPoint(V3d.Zero, ref closest);
+
+            ClassicAssert.IsTrue(found);
+            AssertClosest(closest, set, 2, new V3d(0.25, 0.0, 0.0), 0.0625, stack);
+
+            closest = InitialResult(set, 100.0, stack);
+            var pointFilterCalls = 0;
+            found = tree.ClosestPoint(
+                V3d.Zero,
+                (_, index) => index == 1,
+                (_, _, _, _) => { pointFilterCalls++; return true; },
+                ref closest
+                );
+
+            ClassicAssert.IsTrue(found);
+            ClassicAssert.AreEqual(0, pointFilterCalls);
+            AssertClosest(closest, set, 1, new V3d(8.0, 0.0, 0.0), 64.0, stack);
+
+            closest = InitialResult(set, 0.01, stack);
+            var unchanged = closest;
+            found = tree.ClosestPoint(V3d.Zero, ref closest);
+            ClassicAssert.IsFalse(found);
+            AssertUnchanged(closest, unchanged);
+        }
+
+        [Test]
+        public void BoxSetKdTreeClosestPointMatchesBruteForceAcrossLeaves()
+        {
+            var boxes = Enumerable.Range(0, 96)
+                .Select(i =>
+                {
+                    var min = new V3d((i % 12) * 2.0, ((i / 12) % 4) * 3.0, (i / 48) * 4.0);
+                    return new Box3d(min, min + new V3d(0.4, 0.6, 0.8));
+                })
+                .ToArray();
+            var set = new IntersectableBoxSet(boxes);
+            var tree = CreateTree(set);
+            ClassicAssert.Greater(tree.Tree.Leafs().Count(), 1);
+
+            for (var i = 0; i < 48; i++)
+            {
+                var query = new V3d((i * 17 % 25) - 1.25, (i * 11 % 15) - 1.5, (i * 7 % 9) - 0.75);
+                const double cutoffSquared = 400.0;
+                var expected = BruteForceBox(boxes, query, cutoffSquared, index => (index % 4) != 1);
+                var stack = new List<SetObject> { new(set, i) };
+                var closest = InitialResult(set, cutoffSquared, stack);
+
+                var found = tree.ClosestPoint(query, (_, index) => (index % 4) != 1, null, ref closest);
+
+                ClassicAssert.AreEqual(expected.Index >= 0, found);
+                if (found)
+                    AssertClosest(closest, set, expected.Index, expected.Point, expected.DistanceSquared, stack);
+            }
+        }
+
+        [Test]
+        public void TriangleSetKdTreeClosestPointMatchesBruteForceAcrossLeaves()
+        {
+            var triangles = Enumerable.Range(0, 96)
+                .Select(i =>
+                {
+                    var center = new V3d((i % 12) * 2.0, ((i / 12) % 4) * 3.0, (i / 48) * 4.0);
+                    return new[]
+                    {
+                        center + new V3d(-0.5, -0.5, 0.0),
+                        center + new V3d( 0.5, -0.5, 0.0),
+                        center + new V3d( 0.0,  0.5, 0.0)
+                    };
+                })
+                .ToArray();
+            var positions = triangles.SelectMany(t => t).Select(p => (V3f)p).ToArray();
+            var set = new IntersectableTriangleSet(positions);
+            var tree = CreateTree(set);
+            ClassicAssert.Greater(tree.Tree.Leafs().Count(), 1);
+
+            for (var i = 0; i < 48; i++)
+            {
+                var query = new V3d((i * 13 % 25) - 1.1, (i * 7 % 15) - 1.3, (i * 5 % 9) - 0.6);
+                const double cutoffSquared = 400.0;
+                var expected = BruteForceTriangle(triangles, query, cutoffSquared, index => (index % 3) != 0);
+                var stack = new List<SetObject> { new(set, i) };
+                var closest = InitialResult(set, cutoffSquared, stack);
+
+                var found = tree.ClosestPoint(query, (_, index) => (index % 3) != 0, null, ref closest);
+
+                ClassicAssert.AreEqual(expected.Index >= 0, found);
+                if (found)
+                    AssertClosest(closest, set, expected.Index, expected.Point, expected.DistanceSquared, stack);
+            }
+        }
+
+        private static Box3d[] CreateDirectBoxes()
+            => new[]
+            {
+                new Box3d(new V3d(1.0, -1.0, -1.0), new V3d(2.0, 1.0, 1.0)),
+                new Box3d(new V3d(8.0, -1.0, -1.0), new V3d(9.0, 1.0, 1.0)),
+                new Box3d(new V3d(0.25, -1.0, -1.0), new V3d(0.5, 1.0, 1.0))
+            };
+
+        private static IntersectableTriangleSet CreateDirectTriangleSet(bool indexed)
+        {
+            static V3d[] Triangle(double x) =>
+                new[]
+                {
+                    new V3d(x, -1.0, -1.0),
+                    new V3d(x,  1.0, -1.0),
+                    new V3d(x,  0.0,  1.0)
+                };
+
+            var triangles = new[] { Triangle(1.0), Triangle(8.0), Triangle(0.25) };
+            if (!indexed)
+                return new IntersectableTriangleSet(triangles.SelectMany(t => t).Select(p => (V3f)p).ToArray());
+
+            var positions = triangles.Reverse().SelectMany(t => t).Select(p => (V3f)p).ToArray();
+            var indices = new[] { 6, 7, 8, 3, 4, 5, 0, 1, 2 };
+            return new IntersectableTriangleSet(indices, positions);
+        }
+
+        private static KdIntersectionTree CreateTree(IIntersectableObjectSet set)
+            => new(
+                set,
+                KdIntersectionTree.BuildFlags.Raytracing |
+                KdIntersectionTree.BuildFlags.NoMultithreading
+                );
+
+        private static ObjectClosestPoint InitialResult(
+            IIntersectableObjectSet set,
+            double cutoffSquared,
+            List<SetObject> stack
+            )
+            => new()
+            {
+                DistanceSquared = cutoffSquared,
+                Distance = Math.Sqrt(cutoffSquared),
+                Point = s_preservedPoint,
+                Coord = s_preservedCoord,
+                SetObject = new SetObject(set, 71),
+                ObjectStack = stack
+            };
+
+        private static void AssertClosest(
+            ObjectClosestPoint actual,
+            IIntersectableObjectSet expectedSet,
+            int expectedIndex,
+            V3d expectedPoint,
+            double expectedDistanceSquared,
+            List<SetObject> expectedStack
+            )
+        {
+            ClassicAssert.AreEqual(expectedDistanceSquared, actual.DistanceSquared, 1e-12);
+            ClassicAssert.AreEqual(Math.Sqrt(expectedDistanceSquared), actual.Distance, 1e-12);
+            ClassicAssert.AreEqual(expectedPoint, actual.Point);
+            ClassicAssert.AreSame(expectedSet, actual.SetObject.Set);
+            ClassicAssert.AreEqual(expectedIndex, actual.SetObject.Index);
+            ClassicAssert.AreEqual(s_preservedCoord, actual.Coord);
+            ClassicAssert.AreSame(expectedStack, actual.ObjectStack);
+        }
+
+        private static void AssertUnchanged(ObjectClosestPoint actual, ObjectClosestPoint expected)
+        {
+            ClassicAssert.AreEqual(expected.DistanceSquared, actual.DistanceSquared);
+            ClassicAssert.AreEqual(expected.Distance, actual.Distance);
+            ClassicAssert.AreEqual(expected.Point, actual.Point);
+            ClassicAssert.AreEqual(expected.Coord, actual.Coord);
+            ClassicAssert.AreSame(expected.SetObject.Set, actual.SetObject.Set);
+            ClassicAssert.AreEqual(expected.SetObject.Index, actual.SetObject.Index);
+            ClassicAssert.AreSame(expected.ObjectStack, actual.ObjectStack);
+        }
+
+        private static (int Index, V3d Point, double DistanceSquared) BruteForceBox(
+            Box3d[] boxes,
+            V3d query,
+            double cutoffSquared,
+            Func<int, bool> filter
+            )
+        {
+            var index = -1;
+            var point = V3d.NaN;
+            var distanceSquared = cutoffSquared;
+            for (var i = 0; i < boxes.Length; i++)
+            {
+                if (!filter(i)) continue;
+                var candidate = boxes[i].GetClosestPointOn(query);
+                var d2 = Vec.DistanceSquared(query, candidate);
+                if (d2 >= distanceSquared) continue;
+                index = i;
+                point = candidate;
+                distanceSquared = d2;
+            }
+            return (index, point, distanceSquared);
+        }
+
+        private static (int Index, V3d Point, double DistanceSquared) BruteForceTriangle(
+            V3d[][] triangles,
+            V3d query,
+            double cutoffSquared,
+            Func<int, bool> filter
+            )
+        {
+            var index = -1;
+            var point = V3d.NaN;
+            var distanceSquared = cutoffSquared;
+            for (var i = 0; i < triangles.Length; i++)
+            {
+                if (!filter(i)) continue;
+                var triangle = triangles[i];
+                var candidate = query.GetClosestPointOnTriangle(triangle[0], triangle[1], triangle[2]);
+                var d2 = Vec.DistanceSquared(query, candidate);
+                if (d2 >= distanceSquared) continue;
+                index = i;
+                point = candidate;
+                distanceSquared = d2;
+            }
+            return (index, point, distanceSquared);
+        }
+    }
+}

--- a/src/Aardvark.Geometry.Intersection/IIntersectableObjectSet.cs
+++ b/src/Aardvark.Geometry.Intersection/IIntersectableObjectSet.cs
@@ -83,11 +83,10 @@ namespace Aardvark.Geometry
                 );
 
         /// <summary>
-        /// Computes the closest point of all the objects in the supplied
-        /// index array with respect to the query point, as long as its
-        /// closer than the point supplied in closestPoint. Returns true
-        /// if a closer point was found and updates the closestPoint as
-        /// necessary. Note that the supplied filters are not used as of yet.
+        /// Computes the nearest point among the objects in the supplied index-array slice that is strictly closer than the incoming
+        /// <see cref="ObjectClosestPoint.DistanceSquared"/> cutoff. Returns true and updates the distance, point, and set object when a closer
+        /// candidate is found; otherwise returns false and leaves the result unchanged. A null object filter requests no object filtering.
+        /// Object-filter support is implementation-specific, and the point filter is not used as of yet.
         /// </summary>
         bool ClosestPoint(
                 int[] objectIndexArray, int firstIndex, int indexCount,

--- a/src/Aardvark.Geometry.Intersection/IntersectableBoxSet.cs
+++ b/src/Aardvark.Geometry.Intersection/IntersectableBoxSet.cs
@@ -13,7 +13,6 @@
 */
 using Aardvark.Base;
 using System;
-using System.Collections.Generic;
 
 #pragma warning disable IDE0130 // Namespace does not match folder structure
 
@@ -26,6 +25,10 @@ namespace Aardvark.Geometry
 
         public int ObjectCount => m_boxes.Length;
 
+        /// <summary>
+        /// Finds the nearest object in the supplied index-array slice that is accepted by the object filter and is strictly closer than the incoming <see cref="ObjectClosestPoint.DistanceSquared"/> cutoff.
+        /// A null object filter accepts all objects. On success, the distance, point, and set object are updated consistently; unrelated result state is preserved. The point filter is currently ignored.
+        /// </summary>
         public bool ClosestPoint(int[] objectIndexArray, int firstIndex, int indexCount, V3d queryPoint, Func<IIntersectableObjectSet, int, bool> ios_index_objectFilter, Func<IIntersectableObjectSet, int, int, ObjectClosestPoint, bool> ios_index_part_ocp_pointFilter, ref ObjectClosestPoint closestPoint)
         {
             var minDist2 = closestPoint.DistanceSquared;
@@ -35,39 +38,20 @@ namespace Aardvark.Geometry
             for (int i = 0; i < indexCount; i++)
             {
                 var id = objectIndexArray[firstIndex + i];
+                if (ios_index_objectFilter != null && !ios_index_objectFilter(this, id)) continue;
 
-                if (ios_index_objectFilter(this, id))
+                var p = m_boxes[id].GetClosestPointOn(queryPoint);
+                var d = Vec.DistanceSquared(p, queryPoint);
+
+                if (d < minDist2)
                 {
-                    var p = m_boxes[id].GetClosestPointOn(queryPoint);
-                    var d = Vec.DistanceSquared(p, queryPoint);
-
-                    if (d < minDist2)
-                    {
-                        minIndex = id;
-                        minPos = p;
-                    }
+                    minDist2 = d;
+                    minIndex = id;
+                    minPos = p;
                 }
             }
 
-            if (minIndex >= 0)
-            {
-                closestPoint = new ObjectClosestPoint()
-                {
-                    Distance = Fun.Sqrt(minDist2),
-                    DistanceSquared = minDist2,
-                    Point = minPos,
-                    SetObject = new SetObject(this, minIndex),
-                    ObjectStack = [], // TODO
-                    Coord = V2d.Zero // TODO
-
-                };
-
-                return true;
-            }
-            else
-            {
-                return false;
-            }
+            return minIndex >= 0 && closestPoint.Set(minDist2, minPos, this, minIndex);
         }
 
         public Box3d ObjectBoundingBox(int objectIndex = -1)

--- a/src/Aardvark.Geometry.Intersection/IntersectableTriangleSet.cs
+++ b/src/Aardvark.Geometry.Intersection/IntersectableTriangleSet.cs
@@ -13,7 +13,6 @@
 */
 using Aardvark.Base;
 using System;
-using System.Collections.Generic;
 using System.Linq;
 
 namespace Aardvark.Geometry
@@ -54,6 +53,10 @@ namespace Aardvark.Geometry
 
         public int ObjectCount { get; } = indices != null ? indices.Length / 3 : positions.Length / 3;
 
+        /// <summary>
+        /// Finds the nearest object in the supplied index-array slice that is accepted by the object filter and is strictly closer than the incoming <see cref="ObjectClosestPoint.DistanceSquared"/> cutoff.
+        /// A null object filter accepts all objects. On success, the distance, point, and set object are updated consistently; unrelated result state is preserved. The point filter is currently ignored.
+        /// </summary>
         public bool ClosestPoint(int[] objectIndexArray, int firstIndex, int indexCount, V3d queryPoint, Func<IIntersectableObjectSet, int, bool> ios_index_objectFilter, Func<IIntersectableObjectSet, int, int, ObjectClosestPoint, bool> ios_index_part_ocp_pointFilter, ref ObjectClosestPoint closestPoint)
         {
             var minDist2 = closestPoint.DistanceSquared;
@@ -63,40 +66,21 @@ namespace Aardvark.Geometry
             for (int i = 0; i < indexCount; i++)
             {
                 var id = objectIndexArray[firstIndex + i];
+                if (ios_index_objectFilter != null && !ios_index_objectFilter(this, id)) continue;
 
-                if (ios_index_objectFilter(this, id))
+                GetTriangle(id, out V3d p0, out V3d p1, out V3d p2);
+                var p = queryPoint.GetClosestPointOnTriangle(p0, p1, p2);
+                var d = Vec.DistanceSquared(p, queryPoint);
+
+                if (d < minDist2)
                 {
-                    GetTriangle(id, out V3d p0, out V3d p1, out V3d p2);
-                    var p = queryPoint.GetClosestPointOnTriangle(p0, p1, p2);
-                    var d = Vec.DistanceSquared(p, queryPoint);
-
-                    if (d < minDist2)
-                    {
-                        minIndex = id;
-                        minPos = p;
-                    }
+                    minDist2 = d;
+                    minIndex = id;
+                    minPos = p;
                 }
-
             }
 
-            if (minIndex >= 0)
-            {
-                closestPoint = new ObjectClosestPoint()
-                {
-                    Distance = Fun.Sqrt(minDist2),
-                    DistanceSquared = minDist2,
-                    Point = minPos,
-                    SetObject = new SetObject(this, minIndex),
-                    ObjectStack = [], // TODO
-                    Coord = V2d.Zero // TODO
-                };
-
-                return true;
-            }
-            else
-            {
-                return false;
-            }
+            return minIndex >= 0 && closestPoint.Set(minDist2, minPos, this, minIndex);
         }
 
         public Box3d ObjectBoundingBox(int objectIndex = -1)

--- a/src/Aardvark.Geometry.Intersection/KdIntersectionTree.cs
+++ b/src/Aardvark.Geometry.Intersection/KdIntersectionTree.cs
@@ -267,8 +267,8 @@ namespace Aardvark.Geometry
         }
 
         /// <summary>
-        /// Return the closest point of all objects in the kd-tree to the
-        /// supplied query point.
+        /// Finds the nearest point in the kd-tree that is strictly closer than the incoming <see cref="ObjectClosestPoint.DistanceSquared"/> cutoff.
+        /// On success the exact squared distance, distance, point, and set object are updated; otherwise the result is unchanged.
         /// </summary>
         public bool ClosestPoint(
                 V3d query,
@@ -279,9 +279,9 @@ namespace Aardvark.Geometry
         }
 
         /// <summary>
-        /// Return the closest point of all objects in the kd-tree to the
-        /// supplied query point. Note that the supplied filter functions
-        /// are ignored (the functionality has not been implemented yet).
+        /// Finds the nearest accepted point in the kd-tree that is strictly closer than the incoming <see cref="ObjectClosestPoint.DistanceSquared"/> cutoff.
+        /// The object filter is forwarded to the object set and null requests no object filtering. The point filter is currently ignored by object sets
+        /// that do not implement it. On success the exact squared distance, distance, point, and set object are updated; otherwise the result is unchanged.
         /// </summary>
         public bool ClosestPoint(
             V3d query,


### PR DESCRIPTION
## Summary
- track the exact running nearest distance in box and triangle closest-point scans
- treat null object filters as accepting all objects while preserving selective filters, index slices, and the existing unused point-filter policy
- update only `DistanceSquared`, `Distance`, `Point`, and `SetObject`, preserving `Coord` and `ObjectStack`
- feed completed kd-tree leaves tighter distances so later branches can be pruned correctly
- document strict in/out cutoff semantics and add direct plus multi-leaf parity coverage

## Performance
Warmed Release queries over 512 primitives used the existing non-null selective-filter path and produced identical completion checksums:

| Path | Before | After | Allocations before | Allocations after |
| --- | ---: | ---: | ---: | ---: |
| Box direct scan | 8.11 µs | 6.14 µs | 32 B | 0 B |
| Box kd-tree | 3.92 µs | 1.38 µs | 256 B | 0 B |
| Triangle direct scan | 8.58 µs | 7.05 µs | 32 B | 0 B |
| Triangle kd-tree | 3.56 µs | 0.355 µs | 256 B | 0 B |

The repaired scans are allocation-free. Correct distance propagation improves kd-tree queries by 2.8–10×; direct scans also improve. The newly supported null-filter box paths remain allocation-free (2.53 µs direct, 0.121 µs kd-tree).

## Validation
- focused closest-point regressions: 8 passed
- complete Release suite: 450 passed, 2 existing skips
- complete Release solution build with warnings as errors: 0 warnings, 0 errors

Fixes #53.