### PR TITLE
Repair nearest-point queries on temporary trees

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,5 @@
+- [PointSet] fixed nearest-point queries for temporary trees, zero caps, and empty-octant merges (#55)
+
 ### 5.6.3
 - Updated SharpCompress to 0.48.1 to address CVE-2026-44788
 

--- a/ai/POINT_CLOUDS.md
+++ b/ai/POINT_CLOUDS.md
@@ -90,10 +90,31 @@ foreach (var chunk in pointSet.QueryPointsInsideBox(queryBox))
 long count = pointSet.CountPointsInsideBox(queryBox);
 ```
 
+### Nearest-Point Queries
+
+```csharp
+var query = new V3d(10.0, 20.0, 30.0);
+var nearest = pointSet.QueryPointsNearPoint(
+    query,
+    maxDistanceToPoint: 2.0,
+    maxCount: 16
+    );
+
+for (var i = 0; i < nearest.Count; i++)
+{
+    V3d position = nearest.Positions[i];
+    double distance = nearest.Distances[i];
+    // Colors, normals, intensities, classifications, and part indices
+    // use the same source index when present.
+}
+```
+
+`QueryPointsNearPoint` returns at most `maxCount` points inside the finite radius. A zero count always returns an empty result. Processed leaves retain their kd-tree path; temporary import leaves without kd-trees are scanned with bounded nearest-candidate selection and are not modified. The result's `Object` remains the supplied query point even when its containing octant is empty. Octree traversal tightens its search radius to the farthest retained point only after the result has filled the requested count.
+
 ### Spatial Queries with KD-Tree
 
 ```csharp
-// Access node's KD-tree (automatically computed for leaf nodes)
+// Access node's KD-tree (automatically computed for processed leaf nodes)
 var node = pointSet.Root.Value;
 if (node.HasKdTree)
 {

--- a/src/Aardvark.Algodat.Tests/QueryPointsNearPointTests.cs
+++ b/src/Aardvark.Algodat.Tests/QueryPointsNearPointTests.cs
@@ -1,0 +1,298 @@
+﻿/*
+    Copyright (C) 2006-2026. Aardvark Platform Team. http://github.com/aardvark-platform.
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+using Aardvark.Base;
+using Aardvark.Data.Points;
+using Aardvark.Geometry.Points;
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Aardvark.Geometry.Tests
+{
+    [TestFixture]
+    public class QueryPointsNearPointTests
+    {
+        [Test]
+        public void TemporaryLeafUsesBoundedScanWithAlignedAttributes()
+        {
+            var query = new V3d(0.5, 0.5, 0.5);
+            var fixture = CreateFixture(
+                new[]
+                {
+                    query,
+                    query + new V3d(0.1, 0.0, 0.0),
+                    query + new V3d(0.0, 0.2, 0.0),
+                    query + new V3d(0.0, 0.0, 0.3),
+                    query + new V3d(0.4, 0.0, 0.0)
+                },
+                splitLimit: 32,
+                isTemporary: true,
+                partIndices: new[] { 200, 201, 202, 203, 204 }
+                );
+            var root = fixture.PointSet.Root.Value;
+            ClassicAssert.IsTrue(root.IsLeaf);
+            ClassicAssert.IsFalse(root.HasKdTree);
+
+            var result = fixture.PointSet.QueryPointsNearPoint(query, 0.35, 3);
+
+            AssertResult(result, fixture, query, new[] { 0, 1, 2 }, i => 200 + i);
+            ClassicAssert.IsFalse(root.HasKdTree);
+        }
+
+        [Test]
+        public void SubdividedTemporaryTreePreservesQueryAcrossEmptyOctant()
+        {
+            var query = new V3d(0.25, 0.25, 0.25);
+            var fixture = CreateFixture(
+                new[]
+                {
+                    new V3d(0.55, 0.55, 0.55),
+                    new V3d(0.65, 0.55, 0.55),
+                    new V3d(0.55, 0.70, 0.55),
+                    new V3d(0.55, 0.55, 0.80),
+                    new V3d(0.75, 0.75, 0.55),
+                    new V3d(0.90, 0.60, 0.70)
+                },
+                splitLimit: 2,
+                isTemporary: true,
+                partIndices: 42
+                );
+            var root = fixture.PointSet.Root.Value;
+            ClassicAssert.IsFalse(root.IsLeaf);
+            ClassicAssert.IsNull(root.Subnodes![root.GetSubIndex(query)]);
+            ClassicAssert.IsTrue(Leaves(root).All(leaf => !leaf.HasKdTree));
+            var expected = BruteForceIndices(fixture.Positions, query, 2.0, 3);
+
+            var result = fixture.PointSet.QueryPointsNearPoint(query, 2.0, 3);
+
+            AssertResult(result, fixture, query, expected, _ => 42);
+            ClassicAssert.AreEqual(query, result.Object);
+            ClassicAssert.IsTrue(Leaves(root).All(leaf => !leaf.HasKdTree));
+        }
+
+        [Test]
+        public void TemporaryAndProcessedTreesMatchBruteForce()
+        {
+            var random = new Random(1977);
+            var positions = new V3d[96].SetByIndex(_ => new V3d(
+                0.01 + random.NextDouble() * 0.98,
+                0.01 + random.NextDouble() * 0.98,
+                0.01 + random.NextDouble() * 0.98
+                ));
+            var perPointParts = new int[positions.Length].SetByIndex(i => 300 + i);
+            var temporary = CreateFixture(positions, 4, isTemporary: true, perPointParts);
+            var processed = CreateFixture(positions, 4, isTemporary: false, perPointParts);
+            var query = new V3d(0.31, 0.43, 0.57);
+            const double radius = 0.5;
+            const int maxCount = 11;
+            var expected = BruteForceIndices(processed.Positions, query, radius, maxCount);
+
+            ClassicAssert.IsTrue(Leaves(temporary.PointSet.Root.Value).All(leaf => !leaf.HasKdTree));
+            ClassicAssert.IsTrue(Leaves(processed.PointSet.Root.Value).All(leaf => leaf.HasKdTree));
+
+            var scanned = temporary.PointSet.QueryPointsNearPoint(query, radius, maxCount);
+            var indexed = processed.PointSet.QueryPointsNearPoint(query, radius, maxCount);
+
+            AssertResult(scanned, temporary, query, expected, i => perPointParts[i]);
+            AssertResult(indexed, processed, query, expected, i => perPointParts[i]);
+
+            var scannedDistances = DistancesBySourceIndex(scanned);
+            var indexedDistances = DistancesBySourceIndex(indexed);
+            foreach (var sourceIndex in expected)
+                ClassicAssert.AreEqual(indexedDistances[sourceIndex], scannedDistances[sourceIndex], 1e-7);
+        }
+
+        [Test]
+        public void ZeroMaxCountIsAlwaysEmpty()
+        {
+            var positions = new[]
+            {
+                new V3d(0.2, 0.2, 0.2),
+                new V3d(0.4, 0.4, 0.4),
+                new V3d(0.8, 0.8, 0.8)
+            };
+            var temporary = CreateFixture(positions, 16, isTemporary: true, partIndices: null);
+            var processed = CreateFixture(positions, 16, isTemporary: false, partIndices: null);
+
+            var scanned = temporary.PointSet.QueryPointsNearPoint(V3d.Zero, double.MaxValue, 0);
+            var indexed = processed.PointSet.QueryPointsNearPoint(V3d.Zero, double.MaxValue, 0);
+            var nodeResult = temporary.PointSet.Root.Value.QueryPointsNearPoint(V3d.Zero, double.MaxValue, 0);
+
+            ClassicAssert.IsTrue(scanned.IsEmpty);
+            ClassicAssert.IsTrue(indexed.IsEmpty);
+            ClassicAssert.IsTrue(nodeResult.IsEmpty);
+            ClassicAssert.AreEqual(0, scanned.Count);
+            ClassicAssert.AreEqual(0, indexed.Count);
+            ClassicAssert.AreEqual(0, nodeResult.Count);
+        }
+
+        [Test]
+        public void FiniteRadiusReturnsEveryAvailablePointBelowCap()
+        {
+            var query = new V3d(0.1, 0.1, 0.1);
+            var positions = new[]
+            {
+                query + new V3d(0.05, 0.0, 0.0),
+                query + new V3d(0.15, 0.0, 0.0),
+                query + new V3d(0.25, 0.0, 0.0),
+                query + new V3d(0.35, 0.0, 0.0),
+                query + new V3d(0.55, 0.0, 0.0)
+            };
+            var fixture = CreateFixture(positions, 1, isTemporary: true, partIndices: 7);
+            var expected = BruteForceIndices(fixture.Positions, query, 0.4, 10);
+
+            var result = fixture.PointSet.QueryPointsNearPoint(query, 0.4, 10);
+
+            AssertResult(result, fixture, query, expected, _ => 7);
+            ClassicAssert.AreEqual(4, result.Count);
+        }
+
+        private sealed class Fixture
+        {
+            public PointSet PointSet { get; }
+            public V3d[] Positions { get; }
+            public C4b[] Colors { get; }
+            public V3f[] Normals { get; }
+            public int[] Intensities { get; }
+            public byte[] Classifications { get; }
+
+            public Fixture(
+                PointSet pointSet,
+                V3d[] positions,
+                C4b[] colors,
+                V3f[] normals,
+                int[] intensities,
+                byte[] classifications
+                )
+            {
+                PointSet = pointSet;
+                Positions = positions;
+                Colors = colors;
+                Normals = normals;
+                Intensities = intensities;
+                Classifications = classifications;
+            }
+        }
+
+        private static Fixture CreateFixture(
+            V3d[] positions,
+            int splitLimit,
+            bool isTemporary,
+            object partIndices
+            )
+        {
+            var colors = new C4b[positions.Length].SetByIndex(i =>
+                new C4b((byte)(i + 1), (byte)(i + 21), (byte)(i + 41), byte.MaxValue)
+                );
+            var normals = new V3f[positions.Length].SetByIndex(i => new V3f(i + 1, i + 2, i + 3).Normalized);
+            var intensities = new int[positions.Length].SetByIndex(i => 1000 + i);
+            var classifications = new byte[positions.Length].SetByIndex(i => (byte)(50 + i));
+            var storage = PointCloud.CreateInMemoryStore(cache: default);
+            var root = InMemoryPointSet.Build(
+                positions, colors, normals, intensities, classifications, partIndices,
+                Cell.Unit, splitLimit
+                ).ToPointSetNode(storage, isTemporaryImportNode: true);
+            var pointSet = new PointSet(storage, Guid.NewGuid().ToString(), root.Id, splitLimit);
+            if (!isTemporary)
+                pointSet = pointSet.GenerateLod(ImportConfig.Default.WithRandomKey());
+            var storedPositions = new V3d[positions.Length];
+            foreach (var chunk in pointSet.QueryAllPoints())
+            {
+                for (var i = 0; i < chunk.Count; i++)
+                    storedPositions[chunk.Intensities[i] - 1000] = chunk.Positions[i];
+            }
+            return new Fixture(pointSet, storedPositions, colors, normals, intensities, classifications);
+        }
+
+        private static IEnumerable<IPointCloudNode> Leaves(IPointCloudNode node)
+        {
+            if (node.IsLeaf)
+            {
+                yield return node;
+                yield break;
+            }
+
+            foreach (var subnode in node.Subnodes!)
+            {
+                if (subnode == null) continue;
+                foreach (var leaf in Leaves(subnode.Value)) yield return leaf;
+            }
+        }
+
+        private static int[] BruteForceIndices(
+            V3d[] positions,
+            V3d query,
+            double radius,
+            int maxCount
+            )
+            => positions
+                .Select((position, index) => (Index: index, Distance: (position - query).Length))
+                .Where(x => x.Distance <= radius)
+                .OrderBy(x => x.Distance)
+                .Take(maxCount)
+                .Select(x => x.Index)
+                .ToArray();
+
+        private static Dictionary<int, double> DistancesBySourceIndex(PointsNearObject<V3d> result)
+        {
+            var distances = new Dictionary<int, double>();
+            for (var i = 0; i < result.Count; i++)
+                distances.Add(result.Intensities![i] - 1000, result.Distances![i]);
+            return distances;
+        }
+
+        private static void AssertResult(
+            PointsNearObject<V3d> result,
+            Fixture fixture,
+            V3d query,
+            int[] expectedIndices,
+            Func<int, int> expectedPartIndex
+            )
+        {
+            ClassicAssert.AreEqual(query, result.Object);
+            ClassicAssert.AreEqual(expectedIndices.Length, result.Count);
+            ClassicAssert.IsNotNull(result.Colors);
+            ClassicAssert.IsNotNull(result.Normals);
+            ClassicAssert.IsNotNull(result.Intensities);
+            ClassicAssert.IsNotNull(result.Classifications);
+            ClassicAssert.IsNotNull(result.PartIndices);
+            ClassicAssert.IsNotNull(result.Distances);
+            ClassicAssert.AreEqual(result.Count, result.Colors!.Length);
+            ClassicAssert.AreEqual(result.Count, result.Normals!.Length);
+            ClassicAssert.AreEqual(result.Count, result.Intensities!.Length);
+            ClassicAssert.AreEqual(result.Count, result.Classifications!.Length);
+            ClassicAssert.AreEqual(result.Count, result.PartIndices!.Length);
+            ClassicAssert.AreEqual(result.Count, result.Distances!.Length);
+
+            var expected = expectedIndices.ToHashSet();
+            var actual = new HashSet<int>();
+            for (var i = 0; i < result.Count; i++)
+            {
+                var sourceIndex = result.Intensities[i] - 1000;
+                ClassicAssert.IsTrue(expected.Contains(sourceIndex));
+                ClassicAssert.IsTrue(actual.Add(sourceIndex));
+                ClassicAssert.AreEqual(fixture.Positions[sourceIndex], result.Positions[i]);
+                ClassicAssert.AreEqual(fixture.Colors[sourceIndex], result.Colors[i]);
+                ClassicAssert.AreEqual(fixture.Normals[sourceIndex], result.Normals[i]);
+                ClassicAssert.AreEqual(fixture.Intensities[sourceIndex], result.Intensities[i]);
+                ClassicAssert.AreEqual(fixture.Classifications[sourceIndex], result.Classifications[i]);
+                ClassicAssert.AreEqual(expectedPartIndex(sourceIndex), result.PartIndices[i]);
+                ClassicAssert.AreEqual((result.Positions[i] - query).Length, result.Distances[i], 1e-6);
+            }
+            ClassicAssert.IsTrue(expected.SetEquals(actual));
+        }
+    }
+}

--- a/src/Aardvark.Geometry.PointSet/Octrees/PointsNearObject.cs
+++ b/src/Aardvark.Geometry.PointSet/Octrees/PointsNearObject.cs
@@ -40,6 +40,7 @@ public class CellQueryResult(IPointCloudNode cell, bool isFullyInside)
 }
 
 /// <summary>
+/// Point-query result with aligned positions, distances, and optional standard attributes.
 /// </summary>
 public class PointsNearObject<T>
 {
@@ -48,13 +49,13 @@ public class PointsNearObject<T>
         default!, 0.0, [], [], [], [], [], [], []
         );
 
-    /// <summary></summary>
+    /// <summary>The object used as the query target.</summary>
     public T Object { get; }
 
     /// <summary></summary>
     public double MaxDistance { get; }
 
-    /// <summary></summary>
+    /// <summary>Retained positions.</summary>
     public V3d[] Positions { get; }
 
     /// <summary></summary>
@@ -72,7 +73,7 @@ public class PointsNearObject<T>
     /// <summary></summary>
     public byte[]? Classifications { get; }
 
-    /// <summary></summary>
+    /// <summary>Distances aligned with <see cref="Positions"/> and all available standard attributes.</summary>
     public double[]? Distances { get; }
 
     /// <summary></summary>
@@ -100,13 +101,20 @@ public class PointsNearObject<T>
     public bool IsEmpty => Positions.Length == 0;
 
     /// <summary>
-    /// Returns this PointsNearObject merged with other PointsNearObject.
+    /// Returns this result merged with <paramref name="other"/>, retaining at most <paramref name="maxCount"/> nearest entries.
+    /// If this result is empty, the nonempty result's query <see cref="Object"/> is preserved.
     /// </summary>
     public PointsNearObject<T> Merge(PointsNearObject<T> other, int maxCount)
     {
         if (maxCount < 0) throw new ArgumentOutOfRangeException(nameof(maxCount));
         if (maxCount == 0) return Empty;
         if (other == null || other.IsEmpty) return this;
+        if (IsEmpty)
+        {
+            return other.Count <= maxCount
+                ? other
+                : other.OrderedByDistanceAscending().Take(maxCount);
+        }
 
         var merged = new PointsNearObject<T>(Object,
             Math.Max(MaxDistance, other.MaxDistance),

--- a/src/Aardvark.Geometry.PointSet/Queries/QueriesV3d.cs
+++ b/src/Aardvark.Geometry.PointSet/Queries/QueriesV3d.cs
@@ -15,6 +15,7 @@
 using Aardvark.Base;
 using Aardvark.Data.Points;
 using System;
+using System.Collections.Generic;
 
 namespace Aardvark.Geometry.Points;
 
@@ -25,7 +26,8 @@ public static partial class Queries
     #region Query points
 
     /// <summary>
-    /// Points within given distance to a query point.
+    /// Returns at most <paramref name="maxCount"/> nearest points within <paramref name="maxDistanceToPoint"/> of <paramref name="query"/>.
+    /// A zero count returns an empty result. Temporary leaves without kd-trees are scanned without creating or persisting an index.
     /// </summary>
     public static PointsNearObject<V3d> QueryPointsNearPoint(
         this PointSet self, V3d query, double maxDistanceToPoint, int maxCount
@@ -42,13 +44,15 @@ public static partial class Queries
         => QueryPointsNearPointCustom(self.Root.Value, query, maxDistanceToPoint, maxCount, customAttributes);
 #endif
     /// <summary>
-    /// Points within given distance to a query point.
+    /// Returns at most <paramref name="maxCount"/> nearest points within <paramref name="maxDistanceToPoint"/> of <paramref name="query"/>.
+    /// A zero count returns an empty result. Temporary leaves without kd-trees are scanned without creating or persisting an index.
+    /// Returned distances and all available standard attributes use the same retained source indices.
     /// </summary>
     public static PointsNearObject<V3d> QueryPointsNearPoint(
         this IPointCloudNode node, V3d query, double maxDistanceToPoint, int maxCount
         )
     {
-        if (node == null) return PointsNearObject<V3d>.Empty;
+        if (node == null || maxCount == 0) return PointsNearObject<V3d>.Empty;
 
         // if query point is farther from bounding box than maxDistanceToPoint,
         // then there cannot be a result and we are done
@@ -63,8 +67,12 @@ public static partial class Queries
 #endif
 
             var center = node.Center;
-
-            var closest = node.KdTree!.Value.GetClosest((V3f)(query - center), (float)maxDistanceToPoint, maxCount).ToArray();
+            var queryLocal = (V3f)(query - center);
+            var maxDistance = (float)maxDistanceToPoint;
+            var closest = node.HasKdTree
+                ? node.KdTree.Value.GetClosest(queryLocal, maxDistance, maxCount).ToArray()
+                : GetClosestByScan(nodePositions.Value, queryLocal, maxDistance, maxCount)
+                ;
             if (closest.Length > 0)
             {
                 var ia = closest.Map(x => (int)x.Index);
@@ -90,7 +98,7 @@ public static partial class Queries
             var index = node.GetSubIndex(query);
             var n = node.Subnodes![index];
             var result = n != null ? n.Value.QueryPointsNearPoint(query, maxDistanceToPoint, maxCount) : PointsNearObject<V3d>.Empty;
-            if (!result.IsEmpty && result.MaxDistance < maxDistanceToPoint) maxDistanceToPoint = result.MaxDistance;
+            maxDistanceToPoint = GetPruningDistance(result, maxCount, maxDistanceToPoint);
 
             // now traverse other octants
             for (var i = 0; i < 8; i++)
@@ -100,11 +108,43 @@ public static partial class Queries
                 if (n == null) continue;
                 var x = n.Value.QueryPointsNearPoint(query, maxDistanceToPoint, maxCount);
                 result = result.Merge(x, maxCount);
-                if (!result.IsEmpty && result.MaxDistance < maxDistanceToPoint) maxDistanceToPoint = result.MaxDistance;
+                maxDistanceToPoint = GetPruningDistance(result, maxCount, maxDistanceToPoint);
             }
 
             return result;
         }
+    }
+
+    private static IndexDist<float>[] GetClosestByScan(
+        V3f[] positions,
+        V3f query,
+        float maxDistance,
+        int maxCount
+        )
+    {
+        var closest = new List<IndexDist<float>>(Math.Min(maxCount, positions.Length));
+        for (var i = 0; i < positions.Length; i++)
+        {
+            var distance = Vec.Distance(query, positions[i]);
+            if (distance > maxDistance) continue;
+
+            closest.HeapDescendingEnqueue(new IndexDist<float>(i, distance));
+            if (closest.Count > maxCount) closest.HeapDescendingDequeue();
+        }
+        return closest.ToArray();
+    }
+
+    private static double GetPruningDistance(
+        PointsNearObject<V3d> result,
+        int maxCount,
+        double currentDistance
+        )
+    {
+        if (result.Count < maxCount || result.Distances == null) return currentDistance;
+
+        var farthest = 0.0;
+        foreach (var distance in result.Distances) farthest = Math.Max(farthest, distance);
+        return Math.Min(currentDistance, farthest);
     }
 
 #if TODO


### PR DESCRIPTION
## Summary
- preserve the existing kd-tree leaf path and scan kd-tree-free temporary leaves with a bounded max-heap
- materialize positions, distances, and every available standard attribute from identical source indices
- return an empty result immediately for `maxCount == 0`
- preserve the query object when an empty branch is merged with a nonempty result
- tighten octree pruning only after the retained result reaches the requested cap
- document temporary-tree, cutoff, merge, and attribute semantics

## Performance
Warmed Release queries used a 32-point cap and produced identical processed-tree checksums before and after:

| Existing kd-tree path | Before | After | Allocations before | Allocations after |
| --- | ---: | ---: | ---: | ---: |
| 8,192-point leaf | 159.6 µs | 118.6 µs | 201.1 KB | 201.1 KB |
| 32,768-point subdivided tree | 143.8 µs | 68.1 µs | 71,259 B | 54,044 B |

The leaf path shows no regression. Cap-aware pruning improves the subdivided query and reduces allocations by 24%. The new fallback measured 134.7 µs for the equivalent temporary leaf and 76.3 µs for the temporary subdivided tree.

## Validation
- nearest-point and existing query tests: 77 passed
- complete Release suite: 447 passed, 2 existing skips
- complete Release solution build with warnings as errors: 0 warnings, 0 errors

Fixes #55.