### PR TITLE
Fix convex-hull complement point queries

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,5 @@
+- [PointSet] fixed convex-hull complement queries and exposed convex-hull count APIs (#59)
+
 ### 5.6.3
 - Updated SharpCompress to 0.48.1 to address CVE-2026-44788
 

--- a/ai/POINT_CLOUDS.md
+++ b/ai/POINT_CLOUDS.md
@@ -90,6 +90,24 @@ foreach (var chunk in pointSet.QueryPointsInsideBox(queryBox))
 long count = pointSet.CountPointsInsideBox(queryBox);
 ```
 
+### Querying Points by Convex Hull
+
+`Hull3d` plane normals point outward. A point is inside when its signed height is nonpositive for every plane, so hull boundaries belong to the inside query and are excluded from its strict outside complement.
+
+```csharp
+var hull = new Hull3d(outwardFacingPlanes);
+
+IEnumerable<Chunk> inside = pointSet.QueryPointsInsideConvexHull(hull);
+IEnumerable<Chunk> outside = pointSet.QueryPointsOutsideConvexHull(hull);
+
+long exactInside = pointSet.CountPointsInsideConvexHull(hull);
+long exactOutside = pointSet.CountPointsOutsideConvexHull(hull);
+long upperInside = pointSet.CountPointsApproximatelyInsideConvexHull(hull);
+long upperOutside = pointSet.CountPointsApproximatelyOutsideConvexHull(hull);
+```
+
+All enumeration and count APIs are also available on `IPointCloudNode`. The approximate counts use cell granularity and are upper bounds for their corresponding exact counts. Passing `minCellExponent` evaluates the selected LoD front consistently for enumeration, exact counts, and approximate counts.
+
 ### Spatial Queries with KD-Tree
 
 ```csharp

--- a/src/Aardvark.Algodat.Tests/ConvexHullQueryTests.cs
+++ b/src/Aardvark.Algodat.Tests/ConvexHullQueryTests.cs
@@ -1,0 +1,327 @@
+﻿/*
+    Copyright (C) 2006-2026. Aardvark Platform Team. http://github.com/aardvark-platform.
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+using Aardvark.Base;
+using Aardvark.Data.Points;
+using Aardvark.Geometry.Points;
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Aardvark.Geometry.Tests
+{
+    [TestFixture]
+    public class ConvexHullQueryTests
+    {
+        [Test]
+        public void BoxHullLeafQueriesUseExactComplementAndBoundarySemantics()
+        {
+            var positions = new[]
+            {
+                new V3d(0.50, 0.50, 0.50),
+                new V3d(0.25, 0.50, 0.50),
+                new V3d(0.75, 0.50, 0.50),
+                new V3d(0.50, 0.25, 0.50),
+                new V3d(0.50, 0.75, 0.50),
+                new V3d(0.50, 0.50, 0.25),
+                new V3d(0.50, 0.50, 0.75),
+                new V3d(0.25, 0.25, 0.50),
+                new V3d(0.25, 0.25, 0.25),
+                new V3d(0.10, 0.50, 0.50),
+                new V3d(0.90, 0.50, 0.50),
+                new V3d(0.50, 0.10, 0.50),
+                new V3d(0.50, 0.90, 0.50),
+                new V3d(0.50, 0.50, 0.10),
+                new V3d(0.50, 0.50, 0.90),
+                new V3d(0.10, 0.10, 0.50),
+                new V3d(0.90, 0.90, 0.90)
+            };
+            var perPointParts = new int[positions.Length].SetByIndex(i => 2000 + i);
+            var fixture = CreateFixture(positions, splitLimit: 64, generateLod: false, perPointParts);
+            var hull = new Hull3d(new Box3d(new V3d(0.25), new V3d(0.75)));
+            var root = fixture.PointSet.Root.Value;
+            ClassicAssert.IsTrue(root.IsLeaf);
+            var front = fixture.PointSet.QueryAllPoints().ToArray();
+
+            AssertAllOverloads(fixture.PointSet, root, hull, front, int.MinValue);
+
+            var inside = ResultIntensities(fixture.PointSet.QueryPointsInsideConvexHull(hull));
+            var outside = ResultIntensities(fixture.PointSet.QueryPointsOutsideConvexHull(hull));
+            for (var i = 0; i <= 8; i++)
+            {
+                ClassicAssert.IsTrue(inside.Contains(1000 + i), $"Expected boundary/interior source index {i} inside.");
+                ClassicAssert.IsFalse(outside.Contains(1000 + i), $"Expected boundary/interior source index {i} excluded from outside.");
+            }
+            for (var i = 9; i < positions.Length; i++)
+            {
+                ClassicAssert.IsFalse(inside.Contains(1000 + i), $"Expected source index {i} outside.");
+                ClassicAssert.IsTrue(outside.Contains(1000 + i), $"Expected source index {i} in complement.");
+            }
+        }
+
+        [Test]
+        public void ObliqueHullSubdividedQueriesMatchBruteForce()
+        {
+            var positions = ObliquePositions();
+            var fixture = CreateFixture(positions, splitLimit: 8, generateLod: true, partIndices: 77);
+            var hull = CreateObliqueHull();
+            var root = fixture.PointSet.Root.Value;
+            ClassicAssert.IsFalse(root.IsLeaf);
+            var front = fixture.PointSet.QueryAllPoints().ToArray();
+
+            AssertAllOverloads(fixture.PointSet, root, hull, front, int.MinValue);
+
+            var inside = ResultIntensities(root.QueryPointsInsideConvexHull(hull));
+            var outside = ResultIntensities(root.QueryPointsOutsideConvexHull(hull));
+            for (var i = 0; i <= 2; i++)
+            {
+                ClassicAssert.IsTrue(inside.Contains(1000 + i));
+                ClassicAssert.IsFalse(outside.Contains(1000 + i));
+            }
+            for (var i = 3; i <= 9; i++)
+            {
+                ClassicAssert.IsFalse(inside.Contains(1000 + i));
+                ClassicAssert.IsTrue(outside.Contains(1000 + i));
+            }
+        }
+
+        [Test]
+        public void ObliqueHullLodFrontMatchesBruteForce()
+        {
+            var fixture = CreateFixture(ObliquePositions(), splitLimit: 8, generateLod: true, partIndices: 77);
+            var hull = CreateObliqueHull();
+            var root = fixture.PointSet.Root.Value;
+            const int minCellExponent = -2;
+            var front = root.QueryPoints(_ => true, _ => false, _ => true, minCellExponent).ToArray();
+            ClassicAssert.IsTrue(front.Length > 1);
+            ClassicAssert.IsTrue(front.Sum(x => x.Count) > 0);
+
+            AssertAllOverloads(fixture.PointSet, root, hull, front, minCellExponent);
+        }
+
+        [Test]
+        public void HullContainsBoxMatchesCornerReferenceWithoutChangingBoundaries()
+        {
+            var hulls = new[]
+            {
+                new Hull3d(new Box3d(new V3d(0.25), new V3d(0.75))),
+                CreateObliqueHull()
+            };
+            var boxes = new List<Box3d>
+            {
+                new(new V3d(0.30), new V3d(0.70)),
+                new(new V3d(0.25), new V3d(0.75)),
+                new(new V3d(0.10), new V3d(0.20)),
+                new(new V3d(0.70), new V3d(0.80)),
+                new(new V3d(0.25, 0.50, 0.50), new V3d(0.25, 0.60, 0.60))
+            };
+            var random = new Random(1969);
+            for (var i = 0; i < 500; i++)
+            {
+                var min = new V3d(random.NextDouble(), random.NextDouble(), random.NextDouble());
+                var max = min + new V3d(random.NextDouble(), random.NextDouble(), random.NextDouble()) * 0.2;
+                boxes.Add(new Box3d(min, max));
+            }
+
+            foreach (var hull in hulls)
+            {
+                foreach (var box in boxes)
+                {
+                    var expected = box.Corners.All(p => hull.Contains(p));
+                    ClassicAssert.AreEqual(expected, hull.Contains(box), $"Hull/box mismatch for {box}.");
+                }
+            }
+        }
+
+        private sealed class Fixture
+        {
+            public PointSet PointSet { get; }
+
+            public Fixture(PointSet pointSet)
+            {
+                PointSet = pointSet;
+            }
+        }
+
+        private sealed class PointRecord
+        {
+            public V3d Position { get; }
+            public C4b Color { get; }
+            public V3f Normal { get; }
+            public int Intensity { get; }
+            public byte Classification { get; }
+            public int PartIndex { get; }
+
+            public PointRecord(
+                V3d position,
+                C4b color,
+                V3f normal,
+                int intensity,
+                byte classification,
+                int partIndex
+                )
+            {
+                Position = position;
+                Color = color;
+                Normal = normal;
+                Intensity = intensity;
+                Classification = classification;
+                PartIndex = partIndex;
+            }
+        }
+
+        private static Fixture CreateFixture(
+            V3d[] positions,
+            int splitLimit,
+            bool generateLod,
+            object partIndices
+            )
+        {
+            var colors = new C4b[positions.Length].SetByIndex(i =>
+                new C4b((byte)(i % 251), (byte)((i + 31) % 251), (byte)((i + 67) % 251), byte.MaxValue)
+                );
+            var normals = new V3f[positions.Length].SetByIndex(i => new V3f(i + 1, i + 2, i + 3).Normalized);
+            var intensities = new int[positions.Length].SetByIndex(i => 1000 + i);
+            var classifications = new byte[positions.Length].SetByIndex(i => (byte)(i % 200));
+            var storage = PointCloud.CreateInMemoryStore(cache: default);
+            var root = InMemoryPointSet.Build(
+                positions, colors, normals, intensities, classifications, partIndices,
+                Cell.Unit, splitLimit
+                ).ToPointSetNode(storage, isTemporaryImportNode: true);
+            var pointSet = new PointSet(storage, Guid.NewGuid().ToString(), root.Id, splitLimit);
+            if (generateLod)
+                pointSet = pointSet.GenerateLod(ImportConfig.Default.WithRandomKey());
+            return new Fixture(pointSet);
+        }
+
+        private static V3d[] ObliquePositions()
+        {
+            var positions = new List<V3d>
+            {
+                new(0.50, 0.50, 0.50),
+                new(0.25, 0.50, 0.50),
+                new(0.25, 0.75, 0.75),
+                new(0.125, 0.50, 0.50),
+                new(0.50, 0.125, 0.50),
+                new(0.50, 0.50, 0.125),
+                new(0.75, 0.75, 0.50),
+                new(0.125, 0.125, 0.50),
+                new(0.125, 0.125, 0.125),
+                new(0.875, 0.875, 0.875)
+            };
+            var coordinates = new[] { 0.125, 0.25, 0.375, 0.50, 0.625, 0.75, 0.875 };
+            foreach (var x in coordinates)
+                foreach (var y in coordinates)
+                    foreach (var z in coordinates)
+                    {
+                        var p = new V3d(x, y, z);
+                        if (!positions.Contains(p)) positions.Add(p);
+                    }
+            return positions.ToArray();
+        }
+
+        private static Hull3d CreateObliqueHull()
+        {
+            var slantedNormal = new V3d(1.0, 1.0, 1.0).Normalized;
+            return new Hull3d(new[]
+            {
+                new Plane3d(-V3d.XAxis, new V3d(0.25, 0.0, 0.0)),
+                new Plane3d(-V3d.YAxis, new V3d(0.0, 0.25, 0.0)),
+                new Plane3d(-V3d.ZAxis, new V3d(0.0, 0.0, 0.25)),
+                new Plane3d(slantedNormal, new V3d(0.25, 0.75, 0.75))
+            });
+        }
+
+        private static void AssertAllOverloads(
+            PointSet pointSet,
+            IPointCloudNode root,
+            Hull3d hull,
+            Chunk[] front,
+            int minCellExponent
+            )
+        {
+            var all = Records(front);
+            var expectedInside = all.Values.Where(x => hull.Contains(x.Position)).ToDictionary(x => x.Intensity);
+            var expectedOutside = all.Values.Where(x => !hull.Contains(x.Position)).ToDictionary(x => x.Intensity);
+            ClassicAssert.AreEqual(all.Count, expectedInside.Count + expectedOutside.Count);
+
+            AssertResult(pointSet.QueryPointsInsideConvexHull(hull, minCellExponent), expectedInside);
+            AssertResult(root.QueryPointsInsideConvexHull(hull, minCellExponent), expectedInside);
+            AssertResult(pointSet.QueryPointsOutsideConvexHull(hull, minCellExponent), expectedOutside);
+            AssertResult(root.QueryPointsOutsideConvexHull(hull, minCellExponent), expectedOutside);
+
+            ClassicAssert.AreEqual(expectedInside.Count, pointSet.CountPointsInsideConvexHull(hull, minCellExponent));
+            ClassicAssert.AreEqual(expectedInside.Count, root.CountPointsInsideConvexHull(hull, minCellExponent));
+            ClassicAssert.AreEqual(expectedOutside.Count, pointSet.CountPointsOutsideConvexHull(hull, minCellExponent));
+            ClassicAssert.AreEqual(expectedOutside.Count, root.CountPointsOutsideConvexHull(hull, minCellExponent));
+
+            var approximateInsidePointSet = pointSet.CountPointsApproximatelyInsideConvexHull(hull, minCellExponent);
+            var approximateInsideNode = root.CountPointsApproximatelyInsideConvexHull(hull, minCellExponent);
+            var approximateOutsidePointSet = pointSet.CountPointsApproximatelyOutsideConvexHull(hull, minCellExponent);
+            var approximateOutsideNode = root.CountPointsApproximatelyOutsideConvexHull(hull, minCellExponent);
+            ClassicAssert.AreEqual(approximateInsidePointSet, approximateInsideNode);
+            ClassicAssert.AreEqual(approximateOutsidePointSet, approximateOutsideNode);
+            ClassicAssert.GreaterOrEqual(approximateInsidePointSet, expectedInside.Count);
+            ClassicAssert.GreaterOrEqual(approximateOutsidePointSet, expectedOutside.Count);
+            ClassicAssert.LessOrEqual(approximateInsidePointSet, all.Count);
+            ClassicAssert.LessOrEqual(approximateOutsidePointSet, all.Count);
+        }
+
+        private static Dictionary<int, PointRecord> Records(IEnumerable<Chunk> chunks)
+        {
+            var result = new Dictionary<int, PointRecord>();
+            foreach (var chunk in chunks)
+            {
+                ClassicAssert.IsTrue(chunk.HasColors);
+                ClassicAssert.IsTrue(chunk.HasNormals);
+                ClassicAssert.IsTrue(chunk.HasIntensities);
+                ClassicAssert.IsTrue(chunk.HasClassifications);
+                ClassicAssert.IsTrue(chunk.HasPartIndices);
+                var partIndices = chunk.TryGetPartIndices();
+                for (var i = 0; i < chunk.Count; i++)
+                {
+                    var intensity = chunk.Intensities[i];
+                    ClassicAssert.IsTrue(result.TryAdd(intensity, new PointRecord(
+                        chunk.Positions[i], chunk.Colors[i], chunk.Normals[i], intensity,
+                        chunk.Classifications[i], partIndices[i]
+                        )));
+                }
+            }
+            return result;
+        }
+
+        private static void AssertResult(
+            IEnumerable<Chunk> chunks,
+            Dictionary<int, PointRecord> expected
+            )
+        {
+            var actual = Records(chunks);
+            CollectionAssert.AreEquivalent(expected.Keys, actual.Keys);
+            foreach (var (intensity, expectedPoint) in expected)
+            {
+                var actualPoint = actual[intensity];
+                ClassicAssert.AreEqual(expectedPoint.Position, actualPoint.Position);
+                ClassicAssert.AreEqual(expectedPoint.Color, actualPoint.Color);
+                ClassicAssert.AreEqual(expectedPoint.Normal, actualPoint.Normal);
+                ClassicAssert.AreEqual(expectedPoint.Intensity, actualPoint.Intensity);
+                ClassicAssert.AreEqual(expectedPoint.Classification, actualPoint.Classification);
+                ClassicAssert.AreEqual(expectedPoint.PartIndex, actualPoint.PartIndex);
+            }
+        }
+
+        private static HashSet<int> ResultIntensities(IEnumerable<Chunk> chunks)
+            => chunks.SelectMany(x => x.Intensities).ToHashSet();
+    }
+}

--- a/src/Aardvark.Geometry.PointSet/Queries/QueriesHull3d.cs
+++ b/src/Aardvark.Geometry.PointSet/Queries/QueriesHull3d.cs
@@ -14,11 +14,11 @@
 using Aardvark.Base;
 using Aardvark.Data.Points;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Aardvark.Geometry.Points;
 
 /// <summary>
+/// Convex-hull queries expect outward-facing plane normals. Inside includes the boundary; outside is its strict complement.
 /// </summary>
 public static partial class Queries
 {
@@ -58,7 +58,11 @@ public static partial class Queries
     public static IEnumerable<Chunk> QueryPointsOutsideConvexHull(
         this IPointCloudNode self, Hull3d query, int minCellExponent = int.MinValue
         )
-        => QueryPointsInsideConvexHull(self, query.Reversed(), minCellExponent);
+        => QueryPoints(self,
+            n => !query.Intersects(n.BoundingBoxExactGlobal),
+            n => query.Contains(n.BoundingBoxExactGlobal),
+            p => !query.Contains(p),
+            minCellExponent);
 
     #endregion
 
@@ -67,7 +71,7 @@ public static partial class Queries
     /// <summary>
     /// Counts points inside convex hull.
     /// </summary>
-    internal static long CountPointsInsideConvexHull(
+    public static long CountPointsInsideConvexHull(
         this PointSet self, Hull3d query, int minCellExponent = int.MinValue
         )
         => CountPointsInsideConvexHull(self.Root.Value, query, minCellExponent);
@@ -75,7 +79,7 @@ public static partial class Queries
     /// <summary>
     /// Counts points inside convex hull.
     /// </summary>
-    internal static long CountPointsInsideConvexHull(
+    public static long CountPointsInsideConvexHull(
         this IPointCloudNode self, Hull3d query, int minCellExponent = int.MinValue
         )
         => CountPoints(self,
@@ -87,7 +91,7 @@ public static partial class Queries
     /// <summary>
     /// Counts points outside convex hull.
     /// </summary>
-    internal static long CountPointsOutsideConvexHull(
+    public static long CountPointsOutsideConvexHull(
         this PointSet self, Hull3d query, int minCellExponent = int.MinValue
         )
         => CountPointsOutsideConvexHull(self.Root.Value, query, minCellExponent);
@@ -95,10 +99,14 @@ public static partial class Queries
     /// <summary>
     /// Counts points outside convex hull.
     /// </summary>
-    internal static long CountPointsOutsideConvexHull(
+    public static long CountPointsOutsideConvexHull(
         this IPointCloudNode self, Hull3d query, int minCellExponent = int.MinValue
         )
-        => CountPointsInsideConvexHull(self, query.Reversed(), minCellExponent);
+        => CountPoints(self,
+            n => !query.Intersects(n.BoundingBoxExactGlobal),
+            n => query.Contains(n.BoundingBoxExactGlobal),
+            p => !query.Contains(p),
+            minCellExponent);
 
     #endregion
 
@@ -108,7 +116,7 @@ public static partial class Queries
     /// Counts points inside convex hull (approximately).
     /// Result is always equal or greater than exact number.
     /// </summary>
-    internal static long CountPointsApproximatelyInsideConvexHull(
+    public static long CountPointsApproximatelyInsideConvexHull(
         this PointSet self, Hull3d query, int minCellExponent = int.MinValue
         )
         => CountPointsApproximatelyInsideConvexHull(self.Root.Value, query, minCellExponent);
@@ -117,7 +125,7 @@ public static partial class Queries
     /// Counts points inside convex hull (approximately).
     /// Result is always equal or greater than exact number.
     /// </summary>
-    internal static long CountPointsApproximatelyInsideConvexHull(
+    public static long CountPointsApproximatelyInsideConvexHull(
         this IPointCloudNode self, Hull3d query, int minCellExponent = int.MinValue
         )
         => CountPointsApproximately(self,
@@ -129,7 +137,7 @@ public static partial class Queries
     /// Counts points outside convex hull (approximately).
     /// Result is always equal or greater than exact number.
     /// </summary>
-    internal static long CountPointsApproximatelyOutsideConvexHull(
+    public static long CountPointsApproximatelyOutsideConvexHull(
         this PointSet self, Hull3d query, int minCellExponent = int.MinValue
         )
         => CountPointsApproximatelyOutsideConvexHull(self.Root.Value, query, minCellExponent);
@@ -138,7 +146,7 @@ public static partial class Queries
     /// Counts points outside convex hull (approximately).
     /// Result is always equal or greater than exact number.
     /// </summary>
-    internal static long CountPointsApproximatelyOutsideConvexHull(
+    public static long CountPointsApproximatelyOutsideConvexHull(
         this IPointCloudNode self, Hull3d query, int minCellExponent = int.MinValue
         )
         => CountPointsApproximately(self,

--- a/src/Aardvark.Geometry.PointSet/Utils/BaseExtensions.cs
+++ b/src/Aardvark.Geometry.PointSet/Utils/BaseExtensions.cs
@@ -12,7 +12,6 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 using Aardvark.Base;
-using System.Linq;
 using System.Runtime.CompilerServices;
 
 namespace Aardvark.Geometry.Points;
@@ -98,7 +97,7 @@ public static class BaseExtensions
     }
 
     /// <summary>
-    /// Returns true if the Hull3d completely contains the box.
+    /// Returns true if the outward-facing planes of the Hull3d completely contain the valid box, including its boundary.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool Contains(
@@ -106,11 +105,11 @@ public static class BaseExtensions
     {
         var planes = self.PlaneArray;
         var imax = self.PlaneCount;
-        var corners = box.Corners.ToArray();
         for (var i = 0; i < imax; i++)
         {
             var plane = planes[i];
-            for (var j = 0; j < 8; j++) if (plane.Height(corners[j]) > 0) return false;
+            box.GetMinMaxInDirection(plane.Normal, out _, out var max);
+            if (plane.Height(max) > 0) return false;
         }
         return true;
     }


### PR DESCRIPTION
## Summary
- evaluate outside-hull enumeration and exact counts as the direct complement of the original hull instead of intersecting reversed half-spaces
- preserve inclusive-inside, exclusive-outside, exact global-bound pruning, and `minCellExponent` LoD-front semantics
- make all `PointSet` and `IPointCloudNode` exact/approximate convex-hull count overloads public
- make `Hull3d.Contains(Box3d)` allocation-free by testing each plane’s directional maximum corner
- document outward-facing normals, boundary ownership, count APIs, and approximate upper bounds

## Performance
Warmed Release measurements produced identical checksums before and after:

| Path | Before | After | Allocations before | Allocations after |
| --- | ---: | ---: | ---: | ---: |
| Valid hull/box containment | 264.51 ns | 10.10 ns | 480 B | 0 B |
| Non-boundary single-plane outside query | 600.50 µs | 575.75 µs | 1,095,024 B | 972,088 B |

Containment is 26× faster and allocation-free. Outside-query throughput improves 4.1% with 11.2% fewer allocations.

## Validation
- deterministic leaf, subdivided, oblique, boundary, LoD, count, attribute, and part-index regressions
- convex-hull and existing query tests: 76 passed
- complete Release suite: 446 passed, 2 existing skips
- complete Release solution build with warnings as errors: 0 warnings, 0 errors

Fixes #59.