### PR TITLE
Recompute bounds after Chunk position transforms

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,5 @@
+- [PointSet] recompute chunk bounds after replacing or reprojecting positions (#61)
+
 ### 5.6.3
 - Updated SharpCompress to 0.48.1 to address CVE-2026-44788
 

--- a/ai/IMPORTERS.md
+++ b/ai/IMPORTERS.md
@@ -235,12 +235,20 @@ foreach (var chunk in chunks)
 
 **Problem:** Importers do not perform coordinate system transformations. E57 applies pose transformations, but other formats assume the coordinate system is as-stored.
 
-**Solution:** Apply coordinate transformations manually after import if needed:
+**Solution:** Configure reprojection as part of import so transformed coordinates and bounds reach density filtering and octree construction together:
 
 ```csharp
+var rotation = Rot3d.RotationZ(Math.PI / 2);
+var config = ImportConfig.Default
+    .WithStorage(PointCloud.CreateInMemoryStore(cache: default))
+    .WithReproject(positions => positions
+        .Select(p => rotation.Transform(p))
+        .ToArray());
+
 var pointset = PointCloud.Import("scan.las", config);
-var transformed = pointset.Transform(Matrix4x4.FromRotationZ(Math.PI / 2));
 ```
+
+`WithReproject` keeps returned position index `i` paired with source attribute and part-index `i`, and recomputes every transformed `Chunk.BoundingBox`. Avoid post-import position replacement when the octree must represent the transformed coordinate system.
 
 ### 2. Memory Usage with Large Files
 

--- a/ai/POINT_CLOUDS.md
+++ b/ai/POINT_CLOUDS.md
@@ -133,6 +133,11 @@ var chunk = new Chunk(
     bbox: null  // Auto-computed
 );
 
+// Position replacement and mapping preserve aligned optional attributes and
+// part indices, and derive a new bounding box from the resulting coordinates.
+var translatedChunk = chunk.ImmutableMapPositions(p => p + translation);
+var replacedPositions = chunk.WithPositions(newPositions);
+
 // Filter chunk
 var filteredChunk = chunk.ImmutableFilterByBox3d(
     new Box3d(new V3d(-5, -5, -5), new V3d(5, 5, 5))

--- a/src/Aardvark.Algodat.Tests/ChunkTests.cs
+++ b/src/Aardvark.Algodat.Tests/ChunkTests.cs
@@ -155,6 +155,86 @@ namespace Aardvark.Geometry.Tests
         }
 
         [Test]
+        public void Chunk_WithPositionsRecomputesBoundsAndPreservesAlignment()
+        {
+            var sourcePositions = new[] { new V3d(1, 2, 3), new V3d(4, 5, 6), new V3d(-2, 8, 1) };
+            var colors = new[] { C4b.Red, C4b.Green, C4b.Blue };
+            var normals = new[] { V3f.XAxis, V3f.YAxis, V3f.ZAxis };
+            var intensities = new[] { 10, 20, 30 };
+            var classifications = new byte[] { 1, 2, 3 };
+            var partIndices = new[] { 100, 200, 300 };
+            var sourceBounds = new Box3d(new V3d(-100), new V3d(100));
+            var source = new Chunk(
+                sourcePositions, colors, normals, intensities, classifications,
+                partIndices, partIndexRange: null, bbox: sourceBounds
+                );
+            var transformedPositions = sourcePositions.Map(p => p + new V3d(1000, -2000, 3000));
+
+            var transformed = source.WithPositions(transformedPositions);
+
+            ClassicAssert.AreEqual(new Box3d(transformedPositions), transformed.BoundingBox);
+            ClassicAssert.AreEqual(sourceBounds, source.BoundingBox);
+            CollectionAssert.AreEqual(sourcePositions, source.Positions);
+            CollectionAssert.AreEqual(transformedPositions, transformed.Positions);
+            ClassicAssert.AreSame(colors, transformed.Colors);
+            ClassicAssert.AreSame(normals, transformed.Normals);
+            ClassicAssert.AreSame(intensities, transformed.Intensities);
+            ClassicAssert.AreSame(classifications, transformed.Classifications);
+            ClassicAssert.AreSame(partIndices, transformed.PartIndices);
+            CollectionAssert.AreEqual(partIndices, transformed.TryGetPartIndices());
+            ClassicAssert.AreEqual(new Range1i(100, 300), transformed.PartIndexRange);
+        }
+
+        [Test]
+        public void Chunk_ImmutableMapPositionsFusesNonlinearMappingAndBounds()
+        {
+            var positions = new[]
+            {
+                new V3d(-2, 1, 3),
+                new V3d(1, -4, 2),
+                new V3d(3, 2, -1)
+            };
+            var colors = new[] { C4b.Red, C4b.Green, C4b.Blue };
+            var intensities = new[] { 11, 22, 33 };
+            var partIndices = new short[] { 7, 8, 9 };
+            var source = new Chunk(
+                positions, colors, normals: null, intensities, classifications: null,
+                partIndices, partIndexRange: null, bbox: null
+                );
+            var calls = 0;
+            V3d Mapping(V3d p)
+            {
+                calls++;
+                return new V3d(p.X * p.X, p.Y - 2.0 * p.X, p.Z * p.X);
+            }
+            var expected = positions.Map(p => new V3d(p.X * p.X, p.Y - 2.0 * p.X, p.Z * p.X));
+
+            var transformed = source.ImmutableMapPositions(Mapping);
+
+            ClassicAssert.AreEqual(positions.Length, calls);
+            CollectionAssert.AreEqual(expected, transformed.Positions);
+            ClassicAssert.AreEqual(new Box3d(expected), transformed.BoundingBox);
+            CollectionAssert.AreEqual(positions, source.Positions);
+            ClassicAssert.AreSame(colors, transformed.Colors);
+            ClassicAssert.AreSame(intensities, transformed.Intensities);
+            ClassicAssert.AreSame(partIndices, transformed.PartIndices);
+            CollectionAssert.AreEqual(new[] { 7, 8, 9 }, transformed.TryGetPartIndices());
+        }
+
+        [Test]
+        public void Chunk_ImmutableMapPositionsPreservesEmptyBehavior()
+        {
+            var calls = 0;
+            var transformed = Chunk.Empty.ImmutableMapPositions(p => { calls++; return p + V3d.III; });
+            var replaced = Chunk.Empty.WithPositions(Array.Empty<V3d>());
+
+            ClassicAssert.AreSame(Chunk.Empty, transformed);
+            ClassicAssert.AreEqual(0, calls);
+            ClassicAssert.IsTrue(replaced.IsEmpty);
+            ClassicAssert.AreEqual(Box3d.Invalid, replaced.BoundingBox);
+        }
+
+        [Test]
         public void Chunk_ImmutableDeduplicate_1()
         {
             var a = new Chunk(new[] { new V3d(1, 2, 3), new V3d(4, 5, 6), new V3d(1, 2, 3), new V3d(4, 5, 6) });

--- a/src/Aardvark.Algodat.Tests/ImportTests.cs
+++ b/src/Aardvark.Algodat.Tests/ImportTests.cs
@@ -17,6 +17,7 @@ using Aardvark.Geometry.Points;
 using NUnit.Framework;
 using NUnit.Framework.Legacy;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 
@@ -131,6 +132,147 @@ namespace Aardvark.Geometry.Tests
             if (config.ParseConfig.EnabledProperties.PartIndices) chunk = chunk.WithPartIndices(42u, null);
             var pointcloud = PointCloud.Chunks(chunk, config);
             ClassicAssert.IsTrue(pointcloud.BoundingBox == bb + V3d.OIO);
+        }
+
+        [Test]
+        public void ReprojectedChunkUsesTransformedBoundsAcrossOctreeSplits()
+        {
+            var positions = (
+                from x in Enumerable.Range(0, 4)
+                from y in Enumerable.Range(0, 4)
+                from z in Enumerable.Range(0, 4)
+                select new V3d(x, y, z)
+                ).ToArray();
+            var colors = new C4b[positions.Length].SetByIndex(i => new C4b((byte)i, (byte)(i + 1), (byte)(i + 2), byte.MaxValue));
+            var normals = new V3f[positions.Length].SetByIndex(i => new V3f(i + 1, i + 2, i + 3).Normalized);
+            var intensities = new int[positions.Length].SetByIndex(i => 1000 + i);
+            var classifications = new byte[positions.Length].SetByIndex(i => (byte)(i % 32));
+            var partIndices = new short[positions.Length].SetByIndex(i => (short)(200 + i));
+            var chunk = new Chunk(
+                positions, colors, normals, intensities, classifications,
+                partIndices, partIndexRange: null, bbox: null
+                );
+            var sourceBounds = chunk.BoundingBox;
+            var translation = new V3d(1_000_000, -2_000_000, 3_000_000);
+            var expectedPositions = positions.Map(p => p + translation);
+            var expectedBounds = new Box3d(expectedPositions);
+            var config = ImportConfig.Default
+                .WithStorage(PointCloud.CreateInMemoryStore(cache: default))
+                .WithRandomKey()
+                .WithOctreeSplitLimit(2)
+                .WithMaxDegreeOfParallelism(1)
+                .WithReproject(ps => ps.Map(p => p + translation));
+
+            var pointSet = PointCloud.Chunks(chunk, config);
+
+            ClassicAssert.AreEqual(positions.Length, pointSet.PointCount);
+            ClassicAssert.AreEqual(expectedBounds, pointSet.BoundingBox);
+            ClassicAssert.AreEqual(expectedBounds, pointSet.Root.Value.BoundingBoxExactGlobal);
+            ClassicAssert.AreEqual(sourceBounds, chunk.BoundingBox);
+            CollectionAssert.AreEqual(positions, chunk.Positions);
+
+            var allPositions = pointSet.QueryAllPoints().SelectMany(x => x.Positions).ToArray();
+            ClassicAssert.AreEqual(positions.Length, allPositions.Length);
+            ClassicAssert.AreEqual(positions.Length, allPositions.Count(expectedBounds.Contains));
+            var queried = pointSet.QueryPointsInsideBox(expectedBounds.EnlargedBy(0.01)).ToArray();
+            ClassicAssert.AreEqual(positions.Length, queried.Sum(x => x.Count));
+            var seen = new bool[positions.Length];
+            foreach (var result in queried)
+            {
+                var resultParts = result.TryGetPartIndices();
+                for (var i = 0; i < result.Count; i++)
+                {
+                    var sourceIndex = result.Intensities[i] - 1000;
+                    ClassicAssert.IsFalse(seen[sourceIndex]);
+                    seen[sourceIndex] = true;
+                    ClassicAssert.AreEqual(expectedPositions[sourceIndex], result.Positions[i]);
+                    ClassicAssert.AreEqual(colors[sourceIndex], result.Colors[i]);
+                    ClassicAssert.AreEqual(normals[sourceIndex], result.Normals[i]);
+                    ClassicAssert.AreEqual(classifications[sourceIndex], result.Classifications[i]);
+                    ClassicAssert.AreEqual(partIndices[sourceIndex], resultParts[i]);
+                }
+            }
+            ClassicAssert.IsTrue(seen.All(x => x));
+        }
+
+        [Test]
+        public void NonlinearReprojectionRecomputesImportBounds()
+        {
+            var positions = new[]
+            {
+                new V3d(-2, -1, 0.5),
+                new V3d(-1, 2, -0.5),
+                new V3d(0.5, -3, 2),
+                new V3d(3, 1, -2)
+            };
+            V3d Reproject(V3d p) => new(p.X * p.X, p.Y + p.X * p.Z, p.Z * p.Z - p.X);
+            var expected = positions.Map(Reproject);
+            var chunk = new Chunk(positions);
+            var config = ImportConfig.Default
+                .WithStorage(PointCloud.CreateInMemoryStore(cache: default))
+                .WithRandomKey()
+                .WithOctreeSplitLimit(2)
+                .WithMaxDegreeOfParallelism(1)
+                .WithReproject(ps => ps.Map(Reproject));
+
+            var pointSet = PointCloud.Chunks(chunk, config);
+            var actual = pointSet.QueryAllPoints().SelectMany(x => x.Positions).ToArray();
+
+            ClassicAssert.AreEqual(new Box3d(expected), pointSet.BoundingBox);
+            ClassicAssert.AreEqual(new Box3d(expected), pointSet.Root.Value.BoundingBoxExactGlobal);
+            ClassicAssert.AreEqual(expected.Length, actual.Length);
+            foreach (var p in expected)
+                ClassicAssert.IsTrue(actual.Any(q => q.ApproximateEquals(p, 1e-6)));
+        }
+
+        [Test]
+        public void GloballyNormalizedMinDistIsInvariantUnderAlignedTranslation()
+        {
+            var positions = new[]
+            {
+                new V3d( 0.10, 0.10, 0.10), new V3d( 0.20, 0.20, 0.20),
+                new V3d( 0.60, 0.10, 0.10), new V3d( 0.70, 0.20, 0.20),
+                new V3d( 1.10, 0.10, 0.10), new V3d( 1.20, 0.20, 0.20),
+                new V3d(-0.40, 0.10, 0.10), new V3d(-0.30, 0.20, 0.20)
+            };
+            var intensities = new int[positions.Length].SetByIndex(i => 500 + i);
+            var parts = new int[positions.Length].SetByIndex(i => 50 + i);
+            var source = new Chunk(
+                positions, colors: null, normals: null, intensities, classifications: null,
+                parts, partIndexRange: null, bbox: null
+                );
+            var translation = new V3d(16, -8, 4);
+
+            PointSet Import(string key, Func<IList<V3d>, IList<V3d>> reproject)
+            {
+                var config = ImportConfig.Default
+                    .WithStorage(PointCloud.CreateInMemoryStore(cache: default))
+                    .WithKey(key)
+                    .WithMinDist(0.5)
+                    .WithNormalizePointDensityGlobal(true)
+                    .WithOctreeSplitLimit(4)
+                    .WithMaxDegreeOfParallelism(1)
+                    .WithReproject(reproject);
+                return PointCloud.Chunks(source, config);
+            }
+
+            var original = Import("mindist-original", null);
+            var translated = Import("mindist-translated", ps => ps.Map(p => p + translation));
+            var originalChunks = original.QueryAllPoints().ToArray();
+            var translatedChunks = translated.QueryAllPoints().ToArray();
+            var originalIntensities = originalChunks.SelectMany(x => x.Intensities).OrderBy(x => x).ToArray();
+            var translatedIntensities = translatedChunks.SelectMany(x => x.Intensities).OrderBy(x => x).ToArray();
+
+            ClassicAssert.Less(originalIntensities.Length, positions.Length);
+            CollectionAssert.AreEqual(originalIntensities, translatedIntensities);
+            var originalByIntensity = originalChunks
+                .SelectMany(chunk => chunk.Positions.Zip(chunk.Intensities, (position, intensity) => (position, intensity)))
+                .ToDictionary(x => x.intensity, x => x.position);
+            var translatedByIntensity = translatedChunks
+                .SelectMany(chunk => chunk.Positions.Zip(chunk.Intensities, (position, intensity) => (position, intensity)))
+                .ToDictionary(x => x.intensity, x => x.position);
+            foreach (var intensity in originalIntensities)
+                ClassicAssert.IsTrue(translatedByIntensity[intensity].ApproximateEquals(originalByIntensity[intensity] + translation, 1e-6));
         }
 
         [Test]

--- a/src/Aardvark.Data.Points.Base/Chunk.cs
+++ b/src/Aardvark.Data.Points.Base/Chunk.cs
@@ -412,9 +412,10 @@ namespace Aardvark.Data.Points
         }
 
         /// <summary>
-        /// Immutable update of positions.
+        /// Immutable update of positions. The bounding box is recomputed from <paramref name="newPositions"/>;
+        /// optional attributes and part indices retain their source index alignment.
         /// </summary>
-        public Chunk WithPositions(IList<V3d> newPositions) => new(newPositions, Colors, Normals, Intensities, Classifications, PartIndices, PartIndexRange, BoundingBox);
+        public Chunk WithPositions(IList<V3d> newPositions) => new(newPositions, Colors, Normals, Intensities, Classifications, PartIndices, PartIndexRange, bbox: null);
 
         /// <summary>
         /// Immutable update of colors.
@@ -485,8 +486,25 @@ namespace Aardvark.Data.Points
             }
         }
 
+        /// <summary>
+        /// Returns a chunk with mapped positions and bounds derived from the mapped coordinates.
+        /// Optional attributes and part indices retain their source alignment.
+        /// </summary>
         public Chunk ImmutableMapPositions(Func<V3d, V3d> mapping)
-            => IsEmpty ? Empty : new(Positions.Map(mapping), Colors, Normals, Intensities, Classifications, PartIndices, PartIndexRange, BoundingBox);
+        {
+            if (IsEmpty) return Empty;
+
+            var positions = new V3d[Count];
+            var bounds = Box3d.Invalid;
+            for (var i = 0; i < positions.Length; i++)
+            {
+                var position = mapping(Positions[i]);
+                positions[i] = position;
+                bounds.ExtendBy(position);
+            }
+
+            return new Chunk(positions, Colors, Normals, Intensities, Classifications, PartIndices, PartIndexRange, bounds);
+        }
 
         public Chunk ImmutableMergeWith(IEnumerable<Chunk> others)
             => ImmutableMerge(this, ImmutableMerge(others));

--- a/src/Aardvark.Geometry.PointSet/Import/ImportChunks.cs
+++ b/src/Aardvark.Geometry.PointSet/Import/ImportChunks.cs
@@ -90,7 +90,8 @@ public static partial class PointCloud
             }
         });
 
-        // reproject positions
+        // Reproject before density filtering and map/reduce. WithPositions derives
+        // each chunk's bounds from the returned coordinates.
         if (config.Reproject != null)
         {
             Chunk map(Chunk x, CancellationToken ct)

--- a/src/Aardvark.Geometry.PointSet/Octrees/ImportConfig.cs
+++ b/src/Aardvark.Geometry.PointSet/Octrees/ImportConfig.cs
@@ -127,7 +127,10 @@ public class ImportConfig
     /// <summary></summary>
     public ImportConfig WithMaxChunkPointCount(int x) => new(this) { ParseConfig = ParseConfig.WithMaxChunkPointCount(Math.Max(x, 1)) };
 
-    /// <summary></summary>
+    /// <summary>
+    /// Reprojects each chunk's positions before density filtering and octree construction.
+    /// Chunk bounds are recomputed from the returned positions; position index i remains paired with optional attribute index i.
+    /// </summary>
     public ImportConfig WithReproject(Func<IList<V3d>, IList<V3d>> x) => new(this) { Reproject = x };
 
     /// <summary></summary>


### PR DESCRIPTION
## Summary
- recompute `Chunk.BoundingBox` when `WithPositions` replaces coordinates
- fuse `ImmutableMapPositions` mapping and bounds accumulation into one pass
- preserve optional attributes, part indices, source immutability, and empty behavior
- ensure `ImportConfig.WithReproject` supplies corrected bounds to density filtering and octree construction
- replace obsolete post-import transformation guidance with the supported reprojection path

## Performance
Warmed Release imports used 32,768 positions and produced identical checksums before and after:

| Import path | Before | After | Allocations |
| --- | ---: | ---: | ---: |
| Untransformed | 231.500 ms | 234.302 ms | 3.585 MB, unchanged |
| Translated | 432.706 ms | 433.042 ms | 3.586 MB, unchanged |

Both paths are unchanged within run variance; transformed import differs by 0.08%. The untransformed implementation path is untouched, while mapped-position bounds are accumulated without a second transformed-position pass.

## Validation
- chunk and importer tests: 92 passed
- complete Release suite: 448 passed, 2 existing skips
- complete Release solution build with warnings as errors: 0 warnings, 0 errors
- coverage includes translated/nonlinear bounds, aligned attributes and part indices, large-offset subdivision, spatial-query completeness, empty behavior, and globally normalized `MinDist` parity

Fixes #61.