### PR TITLE
Repair ASCII numeric tokenization

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,5 @@
+- [Ascii] support scientific float notation and safely reject malformed or truncated records (#63)
+
 ### 5.6.3
 - Updated SharpCompress to 0.48.1 to address CVE-2026-44788
 

--- a/ai/IMPORTERS.md
+++ b/ai/IMPORTERS.md
@@ -149,6 +149,12 @@ var customChunks = Ascii.Chunks("scan.txt", customFormat.LineDefinition, ParseCo
 - Custom data: `CustomByte`, `CustomInt32`, `CustomFloat32`, `CustomFloat64`
 - `Skip` (ignore field)
 
+**Numeric and line syntax:**
+- Floating-point fields use invariant decimal syntax and accept scientific notation with or without a decimal point (for example, `1e3`, `-2.5E-4`, or `.5e+2`).
+- Floating-point tokens end at a space, tab, CR/LF, or the end of the input buffer.
+- Records may use LF or CRLF endings; a complete final record does not require a trailing newline, and trailing whitespace is accepted.
+- Records with malformed, incomplete, or truncated configured fields are skipped without affecting subsequent records.
+
 **Key Features:**
 - Stream-based line-by-line parsing
 - Empty lines skipped automatically

--- a/src/Aardvark.Algodat.Tests/ParsingTests.cs
+++ b/src/Aardvark.Algodat.Tests/ParsingTests.cs
@@ -145,6 +145,38 @@ namespace Aardvark.Geometry.Tests
             ParseAscii_Float32_Test("-0", 0);
         }
 
+        [TestCase("1e3", 1000.0f)]
+        [TestCase("1E+3", 1000.0f)]
+        [TestCase("-2e-2", -0.02f)]
+        [TestCase("+.5e+2", 50.0f)]
+        [TestCase("5.e-1", 0.5f)]
+        [TestCase("0e9999", 0.0f)]
+        [TestCase("1.25e2 ", 125.0f)]
+        [TestCase("1.25e2\t", 125.0f)]
+        [TestCase("1.25e2\r", 125.0f)]
+        [TestCase("1.25e2\n", 125.0f)]
+        [TestCase("1.25e2\r\n", 125.0f)]
+        public void ParseAscii_Float32ScientificNotationAndDelimiters(string text, float expected)
+            => ParseAscii_Float32_Test(text, expected);
+
+        [TestCase(".")]
+        [TestCase("+")]
+        [TestCase("-.")]
+        [TestCase("e3")]
+        [TestCase("1e")]
+        [TestCase("1e+")]
+        [TestCase("1e-")]
+        [TestCase("1..2")]
+        [TestCase("1e2x")]
+        public void ParseAscii_Float32MalformedTokensAreSkippedAndParsingRecovers(string malformed)
+        {
+            var buffer = Encoding.ASCII.GetBytes($"{malformed}\n2.5e0\n");
+            var data = LineParsers.Custom(buffer, buffer.Length, 0.0, new[] { Token.NormalX }, partIndices: null);
+
+            ClassicAssert.AreEqual(1, data.Count);
+            ClassicAssert.IsTrue(data.Normals[0].X.ApproximateEquals(2.5f, 1e-6f));
+        }
+
         #endregion
 
         #region Float64
@@ -173,6 +205,38 @@ namespace Aardvark.Geometry.Tests
             ParseAscii_Float64_Test("-0.45678", -0.45678);
             ParseAscii_Float64_Test("-.314", -0.314);
             ParseAscii_Float64_Test("-0", 0);
+        }
+
+        [TestCase("1e3", 1000.0)]
+        [TestCase("1E+3", 1000.0)]
+        [TestCase("-2e-12", -2e-12)]
+        [TestCase("+.5e+2", 50.0)]
+        [TestCase("5.e-1", 0.5)]
+        [TestCase("0e9999", 0.0)]
+        [TestCase("1.25e2 ", 125.0)]
+        [TestCase("1.25e2\t", 125.0)]
+        [TestCase("1.25e2\r", 125.0)]
+        [TestCase("1.25e2\n", 125.0)]
+        [TestCase("1.25e2\r\n", 125.0)]
+        public void ParseAscii_Float64ScientificNotationAndDelimiters(string text, double expected)
+            => ParseAscii_Float64_Test(text, expected);
+
+        [TestCase(".")]
+        [TestCase("+")]
+        [TestCase("-.")]
+        [TestCase("e3")]
+        [TestCase("1e")]
+        [TestCase("1e+")]
+        [TestCase("1e-")]
+        [TestCase("1..2")]
+        [TestCase("1e2x")]
+        public void ParseAscii_Float64MalformedTokensAreSkippedAndParsingRecovers(string malformed)
+        {
+            var buffer = Encoding.ASCII.GetBytes($"{malformed}\n2.5e0\n");
+            var data = LineParsers.Custom(buffer, buffer.Length, 0.0, new[] { Token.PositionX }, partIndices: null);
+
+            ClassicAssert.AreEqual(1, data.Count);
+            ClassicAssert.IsTrue(data.Positions[0].X.ApproximateEquals(2.5, 1e-15));
         }
 
         #endregion
@@ -527,6 +591,98 @@ namespace Aardvark.Geometry.Tests
             ClassicAssert.IsTrue(data.Positions[0] == new V3d(1.2, 3.4, 5.6));
             ClassicAssert.IsTrue(data.Colors[0] == new C4b(10, 20, 30));
             ClassicAssert.IsTrue(data.Intensities[0] == 8765);
+        }
+
+        [TestCase("\n")]
+        [TestCase("\r\n")]
+        public void ParseAscii_MultilineRecordsEndingInNormalsSupportCommonLineEndings(string newline)
+        {
+            var text = $"1e0 2e0 3e0 1e-1 2e-1 3e-1{newline}4e0 5e0 6e0 4e-1 5e-1 6e-1{newline}";
+            var buffer = Encoding.ASCII.GetBytes(text);
+            var layout = new[]
+            {
+                Token.PositionX, Token.PositionY, Token.PositionZ,
+                Token.NormalX, Token.NormalY, Token.NormalZ
+            };
+
+            var data = LineParsers.Custom(buffer, buffer.Length, 0.0, layout, partIndices: null);
+            var durableData = LineParsers.CustomDurable(buffer, buffer.Length, 0.0, layout, partIndices: null);
+
+            ClassicAssert.AreEqual(2, data.Count);
+            CollectionAssert.AreEqual(new[] { new V3d(1, 2, 3), new V3d(4, 5, 6) }, data.Positions);
+            ClassicAssert.IsTrue(data.Normals[0].ApproximateEquals(new V3f(0.1, 0.2, 0.3), 1e-6f));
+            ClassicAssert.IsTrue(data.Normals[1].ApproximateEquals(new V3f(0.4, 0.5, 0.6), 1e-6f));
+            CollectionAssert.AreEqual(data.Positions, durableData.Positions);
+            CollectionAssert.AreEqual(data.Normals, durableData.Normals);
+        }
+
+        [Test]
+        public void ParseAscii_TrailingWhitespaceAfterLastFieldIsAccepted()
+        {
+            var buffer = Encoding.ASCII.GetBytes("1e0\t2e0 3e0 \t  \r\n");
+            var layout = new[] { Token.PositionX, Token.PositionY, Token.PositionZ };
+
+            var data = LineParsers.Custom(buffer, buffer.Length, 0.0, layout, partIndices: null);
+
+            ClassicAssert.AreEqual(1, data.Count);
+            ClassicAssert.AreEqual(new V3d(1, 2, 3), data.Positions[0]);
+        }
+
+        [TestCase("1e")]
+        [TestCase("1e+")]
+        [TestCase("-.")]
+        public void ParseAscii_IncompleteFloatingTokensAtBufferEndAreRejected(string text)
+        {
+            var buffer = Encoding.ASCII.GetBytes(text);
+            var doubles = LineParsers.Custom(buffer, buffer.Length, 0.0, new[] { Token.PositionX }, partIndices: null);
+            var floats = LineParsers.Custom(buffer, buffer.Length, 0.0, new[] { Token.NormalX }, partIndices: null);
+
+            ClassicAssert.IsTrue(doubles.IsEmpty);
+            ClassicAssert.IsTrue(floats.IsEmpty);
+        }
+
+        [TestCase("1 2")]
+        [TestCase("1 2 ")]
+        [TestCase("1 2\n")]
+        [TestCase("1 2\r\n")]
+        public void ParseAscii_TruncatedRecordsAreRejected(string text)
+        {
+            var buffer = Encoding.ASCII.GetBytes(text);
+            var layout = new[] { Token.PositionX, Token.PositionY, Token.PositionZ };
+
+            var data = LineParsers.Custom(buffer, buffer.Length, 0.0, layout, partIndices: null);
+
+            ClassicAssert.IsTrue(data.IsEmpty);
+        }
+
+        [Test]
+        public void ParseAscii_ScannersRespectLogicalBufferEnd()
+        {
+            var floatBuffer = Encoding.ASCII.GetBytes("1e3x");
+            var floatData = LineParsers.Custom(floatBuffer, 3, 0.0, new[] { Token.PositionX }, partIndices: null);
+            ClassicAssert.AreEqual(1, floatData.Count);
+            ClassicAssert.AreEqual(1000.0, floatData.Positions[0].X);
+
+            var byteBuffer = Encoding.ASCII.GetBytes("255x");
+            var byteData = LineParsers.Custom(byteBuffer, 3, 0.0, new[] { Token.ColorR }, partIndices: null);
+            ClassicAssert.AreEqual(1, byteData.Count);
+            ClassicAssert.AreEqual(255, byteData.Colors[0].R);
+
+            var skipBuffer = Encoding.ASCII.GetBytes("1 opaque");
+            var skipData = LineParsers.Custom(skipBuffer, skipBuffer.Length, 0.0, new[] { Token.PositionX, Token.Skip }, partIndices: null);
+            ClassicAssert.AreEqual(1, skipData.Count);
+            ClassicAssert.AreEqual(1.0, skipData.Positions[0].X);
+        }
+
+        [Test]
+        public void ParseAscii_ScientificNotationPreservesMinimumDistanceFiltering()
+        {
+            var buffer = Encoding.ASCII.GetBytes("0e0 0 0\n1e-1 0 0\n1e0 0 0\n");
+            var layout = new[] { Token.PositionX, Token.PositionY, Token.PositionZ };
+
+            var data = LineParsers.Custom(buffer, buffer.Length, 0.5, layout, partIndices: null);
+
+            CollectionAssert.AreEqual(new[] { V3d.Zero, V3d.XAxis }, data.Positions);
         }
 
         #endregion

--- a/src/Aardvark.Data.Points.Ascii/LineParsers.cs
+++ b/src/Aardvark.Data.Points.Ascii/LineParsers.cs
@@ -34,7 +34,8 @@ namespace Aardvark.Data.Points
     }
     
     /// <summary>
-    /// Various line parsers.
+    /// Single-pass numeric line parsers for LF- or CRLF-delimited ASCII point records.
+    /// Floating-point fields support invariant decimal and scientific notation.
     /// </summary>
     public static class LineParsers
     {
@@ -83,7 +84,6 @@ namespace Aardvark.Data.Points
             var js = hasIntensity ? new List<int>() : null;
 
             var prev = V3d.PositiveInfinity;
-            var filterDistM = -filterDist;
             var doFilterDist = filterDist > 0.0;
 
             var tokenParsers = layout.Map(x => s_parsers[x]);
@@ -146,7 +146,6 @@ namespace Aardvark.Data.Points
             var js = hasIntensity ? new List<int>() : null;
 
             var prev = V3d.PositiveInfinity;
-            var filterDistM = -filterDist;
             var doFilterDist = filterDist > 0.0;
 
             var tokenParsers = layout.Map(x => s_parsers[x]);
@@ -232,267 +231,307 @@ namespace Aardvark.Data.Points
         #region Private
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool IsDelimiter(byte c)
+            => c == ' ' || c == '\t' || c == '\r' || c == '\n';
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static unsafe bool SkipToNextLine(LineParserState state)
         {
-            while (state.p < state.end && *state.p != '\n') state.p++;
-            state.p++;
-            return state.p < state.end;
+            var p = state.p;
+            while (p < state.end && *p != '\n') p++;
+            if (p < state.end) p++;
+            state.p = p;
+            return p < state.end;
         }
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static unsafe void ParseFloat64(LineParserState state, Action<double> setResult)
         {
-            if (state.p >= state.end) { state.IsInvalid = true; return; }
-
-            while ((*state.p == ' ' || *state.p == '\t') && state.p < state.end) state.p++;
-            if (state.p >= state.end || *state.p == '\n' || *state.p == '\r') { state.IsInvalid = true; return; }
-
-            var minus = *state.p == ((byte)'-');
-            if (minus) state.p++;
-            else if (*state.p == ((byte)'+')) state.p++;
-
-            var x = 0.0;
-            var parse = true;
-            while (parse && state.p < state.end)
+            var p = state.p;
+            var end = state.end;
+            while (p < end && (*p == ' ' || *p == '\t')) p++;
+            if (p >= end || *p == '\n' || *p == '\r')
             {
-                switch ((char)*state.p)
-                {
-                    case '0': x *= 10.0; break;
-                    case '1': x = x * 10.0 + 1.0; break;
-                    case '2': x = x * 10.0 + 2.0; break;
-                    case '3': x = x * 10.0 + 3.0; break;
-                    case '4': x = x * 10.0 + 4.0; break;
-                    case '5': x = x * 10.0 + 5.0; break;
-                    case '6': x = x * 10.0 + 6.0; break;
-                    case '7': x = x * 10.0 + 7.0; break;
-                    case '8': x = x * 10.0 + 8.0; break;
-                    case '9': x = x * 10.0 + 9.0; break;
-                    case '.': parse = false; break;
-                    case '\n':
-                    case '\r':
-                    case '\t':
-                    case ' ': setResult(minus ? -x : x); return;
-                    default: { state.IsInvalid = true; return; }
-                }
-                state.p++;
-            }
-            if (state.p >= state.end) { setResult(minus ? -x : x); return; }
-
-            var y = 0.0;
-            var r = 0.1;
-            var noExponent = true;
-            while (noExponent && state.p < state.end)
-            {
-                switch ((char)*state.p)
-                {
-                    case '0': break;
-                    case '1': y += r; break;
-                    case '2': y += r * 2; break;
-                    case '3': y += r * 3; break;
-                    case '4': y += r * 4; break;
-                    case '5': y += r * 5; break;
-                    case '6': y += r * 6; break;
-                    case '7': y += r * 7; break;
-                    case '8': y += r * 8; break;
-                    case '9': y += r * 9; break;
-                    case 'e':
-                    case 'E': noExponent = false; break;
-                    case '\n':
-                    case '\r':
-                    case '\t':
-                    case ' ': setResult(minus ? -x - y : x + y); return;
-                    default: { state.IsInvalid = true; return; };
-                }
-                r *= 0.1;
-                state.p++;
+                state.p = p;
+                state.IsInvalid = true;
+                return;
             }
 
-            if (!noExponent)
-            {
-                var minusExponent = *state.p == ((byte)'-');
-                if (minusExponent) state.p++;
-                else if (*state.p == ((byte)'+')) state.p++;
+            var minus = *p == '-';
+            if (minus || *p == '+') p++;
 
-                var e = 0;
-                while (state.p < state.end)
+            var value = 0.0;
+            var hasDigits = false;
+            while (p < end)
+            {
+                var digit = (uint)(*p - '0');
+                if (digit > 9) break;
+                value = value * 10.0 + digit;
+                hasDigits = true;
+                p++;
+            }
+
+            var fraction = 0.0;
+            if (p < end && *p == '.')
+            {
+                p++;
+                var scale = 0.1;
+                while (p < end)
                 {
-                    switch ((char)*state.p)
-                    {
-                        case '0': e *= 10; break;
-                        case '1': e = e * 10 + 1; break;
-                        case '2': e = e * 10 + 2; break;
-                        case '3': e = e * 10 + 3; break;
-                        case '4': e = e * 10 + 4; break;
-                        case '5': e = e * 10 + 5; break;
-                        case '6': e = e * 10 + 6; break;
-                        case '7': e = e * 10 + 7; break;
-                        case '8': e = e * 10 + 8; break;
-                        case '9': e = e * 10 + 9; break;
-                        case '\n':
-                        case '\r':
-                        case '\t':
-                        case ' ': setResult((minus ? -x - y : x + y) * Math.Pow(10, minusExponent ? -e : e)); return;
-                        default: { state.IsInvalid = true; return; }
-                    }
-                    state.p++;
+                    var digit = (uint)(*p - '0');
+                    if (digit > 9) break;
+                    fraction += digit * scale;
+                    scale *= 0.1;
+                    hasDigits = true;
+                    p++;
                 }
             }
 
-            setResult(minus ? -x - y : x + y);
+            if (!hasDigits)
+            {
+                state.p = p;
+                state.IsInvalid = true;
+                return;
+            }
+
+            var exponent = 0;
+            var minusExponent = false;
+            if (p < end && (*p == 'e' || *p == 'E'))
+            {
+                p++;
+                if (p < end && (*p == '-' || *p == '+'))
+                {
+                    minusExponent = *p == '-';
+                    p++;
+                }
+
+                var hasExponentDigits = false;
+                while (p < end)
+                {
+                    var digit = (uint)(*p - '0');
+                    if (digit > 9) break;
+                    exponent = exponent < 1000 ? exponent * 10 + (int)digit : 10000;
+                    hasExponentDigits = true;
+                    p++;
+                }
+
+                if (!hasExponentDigits)
+                {
+                    state.p = p;
+                    state.IsInvalid = true;
+                    return;
+                }
+            }
+
+            if (p < end && !IsDelimiter(*p))
+            {
+                state.p = p;
+                state.IsInvalid = true;
+                return;
+            }
+
+            value += fraction;
+            if (exponent != 0 && value != 0.0)
+                value *= Math.Pow(10.0, minusExponent ? -exponent : exponent);
+
+            state.p = p;
+            setResult(minus ? -value : value);
         }
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static unsafe void ParseFloat32(LineParserState state, Action<float> setResult)
         {
-            if (state.p >= state.end) { state.IsInvalid = true; return; }
-
-            while ((*state.p == ' ' || *state.p == '\t') && state.p < state.end) state.p++;
-            if (state.p >= state.end || *state.p == '\n' || *state.p == '\r') { state.IsInvalid = true; return; }
-
-            var minus = *state.p == ((byte)'-');
-            if (minus) state.p++;
-            else if (*state.p == ((byte)'+')) state.p++;
-
-            var x = 0.0f;
-            var parse = true;
-            while (parse && state.p < state.end)
+            var p = state.p;
+            var end = state.end;
+            while (p < end && (*p == ' ' || *p == '\t')) p++;
+            if (p >= end || *p == '\n' || *p == '\r')
             {
-                switch ((char)*state.p)
-                {
-                    case '0': x *= 10.0f; break;
-                    case '1': x = x * 10.0f + 1.0f; break;
-                    case '2': x = x * 10.0f + 2.0f; break;
-                    case '3': x = x * 10.0f + 3.0f; break;
-                    case '4': x = x * 10.0f + 4.0f; break;
-                    case '5': x = x * 10.0f + 5.0f; break;
-                    case '6': x = x * 10.0f + 6.0f; break;
-                    case '7': x = x * 10.0f + 7.0f; break;
-                    case '8': x = x * 10.0f + 8.0f; break;
-                    case '9': x = x * 10.0f + 9.0f; break;
-                    case '.': parse = false; break;
-                    case '\t':
-                    case ' ': setResult(minus ? -x : x); return;
-                    default: { state.IsInvalid = true; return; }
-                }
-                state.p++;
+                state.p = p;
+                state.IsInvalid = true;
+                return;
             }
-            if (state.p >= state.end) { setResult(minus ? -x : x); return; }
 
-            var y = 0.0f;
-            var r = 0.1f;
-            while (state.p < state.end)
+            var minus = *p == '-';
+            if (minus || *p == '+') p++;
+
+            var value = 0.0f;
+            var hasDigits = false;
+            while (p < end)
             {
-                switch ((char)*state.p)
-                {
-                    case '0': break;
-                    case '1': y += r; break;
-                    case '2': y += r * 2; break;
-                    case '3': y += r * 3; break;
-                    case '4': y += r * 4; break;
-                    case '5': y += r * 5; break;
-                    case '6': y += r * 6; break;
-                    case '7': y += r * 7; break;
-                    case '8': y += r * 8; break;
-                    case '9': y += r * 9; break;
-                    case '\t':
-                    case ' ': setResult(minus ? -x - y : x + y); return;
-                    default: { state.IsInvalid = true; return; }
-                }
-                r *= 0.1f;
-                state.p++;
+                var digit = (uint)(*p - '0');
+                if (digit > 9) break;
+                value = value * 10.0f + digit;
+                hasDigits = true;
+                p++;
             }
-            setResult(minus ? -x - y : x + y);
+
+            var fraction = 0.0f;
+            if (p < end && *p == '.')
+            {
+                p++;
+                var scale = 0.1f;
+                while (p < end)
+                {
+                    var digit = (uint)(*p - '0');
+                    if (digit > 9) break;
+                    fraction += digit * scale;
+                    scale *= 0.1f;
+                    hasDigits = true;
+                    p++;
+                }
+            }
+
+            if (!hasDigits)
+            {
+                state.p = p;
+                state.IsInvalid = true;
+                return;
+            }
+
+            var exponent = 0;
+            var minusExponent = false;
+            if (p < end && (*p == 'e' || *p == 'E'))
+            {
+                p++;
+                if (p < end && (*p == '-' || *p == '+'))
+                {
+                    minusExponent = *p == '-';
+                    p++;
+                }
+
+                var hasExponentDigits = false;
+                while (p < end)
+                {
+                    var digit = (uint)(*p - '0');
+                    if (digit > 9) break;
+                    exponent = exponent < 1000 ? exponent * 10 + (int)digit : 10000;
+                    hasExponentDigits = true;
+                    p++;
+                }
+
+                if (!hasExponentDigits)
+                {
+                    state.p = p;
+                    state.IsInvalid = true;
+                    return;
+                }
+            }
+
+            if (p < end && !IsDelimiter(*p))
+            {
+                state.p = p;
+                state.IsInvalid = true;
+                return;
+            }
+
+            value += fraction;
+            if (exponent != 0 && value != 0.0f)
+                value = (float)(value * Math.Pow(10.0, minusExponent ? -exponent : exponent));
+
+            state.p = p;
+            setResult(minus ? -value : value);
         }
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static unsafe void ParseInt(LineParserState state, Action<int> setResult)
         {
-            if (state.p >= state.end) { state.IsInvalid = true; return; }
-
-            while ((*state.p == ' ' || *state.p == '\t') && state.p < state.end) state.p++;
-            if (state.p >= state.end || *state.p == '\n' || *state.p == '\r') { state.IsInvalid = true; return; }
-
-            var minus = *state.p == ((byte)'-');
-            if (minus) state.p++;
-
-            var x = 0;
-            while (state.p < state.end)
+            var p = state.p;
+            var end = state.end;
+            while (p < end && (*p == ' ' || *p == '\t')) p++;
+            if (p >= end || *p == '\n' || *p == '\r')
             {
-                switch ((char)*state.p)
-                {
-                    case '0': x *= 10; break;
-                    case '1': x = x * 10 + 1; break;
-                    case '2': x = x * 10 + 2; break;
-                    case '3': x = x * 10 + 3; break;
-                    case '4': x = x * 10 + 4; break;
-                    case '5': x = x * 10 + 5; break;
-                    case '6': x = x * 10 + 6; break;
-                    case '7': x = x * 10 + 7; break;
-                    case '8': x = x * 10 + 8; break;
-                    case '9': x = x * 10 + 9; break;
-                    case '\r':
-                    case '\n':
-                    case '\t':
-                    case ' ': setResult(minus ? -x : x); return;
-                    default: { state.IsInvalid = true; return; }
-                }
-                state.p++;
+                state.p = p;
+                state.IsInvalid = true;
+                return;
             }
-            setResult(minus ? -x : x);
+
+            var minus = *p == '-';
+            if (minus) p++;
+
+            var value = 0;
+            while (p < end)
+            {
+                var digit = (uint)(*p - '0');
+                if (digit <= 9)
+                {
+                    value = value * 10 + (int)digit;
+                    p++;
+                    continue;
+                }
+
+                if (IsDelimiter(*p))
+                {
+                    state.p = p;
+                    setResult(minus ? -value : value);
+                    return;
+                }
+
+                state.p = p;
+                state.IsInvalid = true;
+                return;
+            }
+
+            state.p = p;
+            setResult(minus ? -value : value);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static unsafe void ParseByte(LineParserState state, Action<byte> setResult)
         {
-            if (state.p >= state.end) { state.IsInvalid = true; return; }
-
-            while (*state.p == ' ' && state.p < state.end) state.p++;
-            if (state.p >= state.end || *state.p == '\n' || *state.p == '\r') { state.IsInvalid = true; return; }
-            
-            var x = 0;
-            while (state.p < state.end)
+            var p = state.p;
+            var end = state.end;
+            while (p < end && *p == ' ') p++;
+            if (p >= end || *p == '\n' || *p == '\r')
             {
-                switch ((char)*state.p)
-                {
-                    case '0': x *= 10; break;
-                    case '1': x = x * 10 + 1; break;
-                    case '2': x = x * 10 + 2; break;
-                    case '3': x = x * 10 + 3; break;
-                    case '4': x = x * 10 + 4; break;
-                    case '5': x = x * 10 + 5; break;
-                    case '6': x = x * 10 + 6; break;
-                    case '7': x = x * 10 + 7; break;
-                    case '8': x = x * 10 + 8; break;
-                    case '9': x = x * 10 + 9; break;
-                    case '\r':
-                    case '\n':
-                    case ' ': if (x < 256) setResult((byte)x); else state.IsInvalid = true; return;
-                    default: { state.IsInvalid = true; return; }
-                }
-                state.p++;
+                state.p = p;
+                state.IsInvalid = true;
+                return;
             }
-            if (x < 256) setResult((byte)x); else state.IsInvalid = true;
+            
+            var value = 0;
+            while (p < end)
+            {
+                var digit = (uint)(*p - '0');
+                if (digit <= 9)
+                {
+                    value = value * 10 + (int)digit;
+                    p++;
+                    continue;
+                }
+
+                if (*p == ' ' || *p == '\r' || *p == '\n')
+                {
+                    state.p = p;
+                    if (value < 256) setResult((byte)value);
+                    else state.IsInvalid = true;
+                    return;
+                }
+
+                state.p = p;
+                state.IsInvalid = true;
+                return;
+            }
+
+            state.p = p;
+            if (value < 256) setResult((byte)value);
+            else state.IsInvalid = true;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static unsafe void ParseSkip(LineParserState state)
         {
-            if (state.p >= state.end) { state.IsInvalid = true; return; }
-
-            while ((*state.p == ' ' || *state.p == '\t') && state.p < state.end) state.p++;
-            if (state.p >= state.end || *state.p == '\n' || *state.p == '\r') { state.IsInvalid = true; return; }
-            
-            while (state.p < state.end)
+            var p = state.p;
+            var end = state.end;
+            while (p < end && (*p == ' ' || *p == '\t')) p++;
+            if (p >= end || *p == '\n' || *p == '\r')
             {
-                switch ((char)*state.p)
-                {
-                    case '\r':
-                    case '\n':
-                    case '\t':
-                    case ' ': return;
-                }
-                state.p++;
+                state.p = p;
+                state.IsInvalid = true;
+                return;
             }
+
+            while (p < end && !IsDelimiter(*p)) p++;
+            state.p = p;
         }
 
         #endregion


### PR DESCRIPTION
## Summary
- accept invariant scientific notation in float32 and float64 fields, with or without a decimal point
- finish numeric tokens correctly at spaces, tabs, CR/LF, and the logical buffer end
- reject malformed and incomplete mantissas/exponents before publishing values, allowing the next record to recover cleanly
- preserve LF/CRLF records whose final configured field is a normal
- guard every unsafe scanner dereference and keep line skipping within the input buffer
- retain existing byte, integer, skip, and minimum-distance semantics

## Performance
Warmed Release parsing of 65,536 standard-decimal records with filtering disabled (median of five runs):

| Layout | Before | After | Change | Allocations |
| --- | ---: | ---: | ---: | ---: |
| XYZRGB | 25.589 ms / 99.09 MiB/s | 17.032 ms / 148.88 MiB/s | 33.4% faster | 38,274,152 B → 38,274,149 B |
| XYZ + normal | 26.938 ms / 136.56 MiB/s | 16.692 ms / 220.38 MiB/s | 38.0% faster | 39,322,582 B → 39,322,582 B |

Checksums matched for both layouts. Local scanner pointers and range-based digit parsing improve throughput without adding allocations.

## Validation
- focused parsing suite: 81 passed
- complete Release suite: 494 passed, 2 existing skips
- complete Release solution build with warnings as errors: 0 warnings, 0 errors
- 52 added cases cover float/double exponent forms, EOF and whitespace delimiters, LF/CRLF normal records, malformed recovery, incomplete EOF tokens, truncated records, logical buffer bounds, trailing whitespace, durable parsing, and minimum-distance filtering

Fixes #63.