### PR TITLE
Repair PolyMesh grouping attribute projection

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,5 @@
+- [PolyMesh] preserve direct and indexed attributes when grouping selected faces (#65)
+
 ### 5.6.3
 - Updated SharpCompress to 0.48.1 to address CVE-2026-44788
 

--- a/ai/POLYMESH.md
+++ b/ai/POLYMESH.md
@@ -116,8 +116,8 @@ var uvIndices = new int[] { 0, 1, 2, 3, 1, 2, 3, 0 }; // 2 quads sharing UVs
 
 mesh.FaceVertexAttributes = new SymbolDict<Array>
 {
-    [PolyMesh.Property.DiffuseColorCoordinates] = uvData,
-    [-PolyMesh.Property.DiffuseColorCoordinates] = uvIndices // negative key for indices
+    [PolyMesh.Property.DiffuseColorCoordinates] = uvIndices,
+    [-PolyMesh.Property.DiffuseColorCoordinates] = uvData
 };
 ```
 
@@ -128,7 +128,7 @@ mesh.FaceVertexAttributes = new SymbolDict<Array>
 | TriangulatedCopy() | Triangulate all faces |
 | SubSetOfFaces(indices, compact) | Extract face subset |
 | Transformed(Trafo3d) | Apply transformation |
-| Group(meshes) | Merge multiple meshes |
+| Group(meshes) | Describe a merge of meshes with compatible attributes |
 | WithoutDegeneratedEdges() | Remove zero-length edges |
 | WithoutDegeneratedFaces() | Remove zero-area faces |
 | GetIndexedGeometry() | Convert to IndexedGeometry for rendering |
@@ -161,10 +161,18 @@ var transformed = mesh.Transformed(trafo);
 
 ### Mesh Grouping
 
+`Group()` returns a grouping descriptor rather than a mesh. Check `Valid` before materializing `Mesh`: validity requires compatible instance attributes, no instance/face key collision, and matching face, vertex, and face-vertex attribute names and value types across all inputs.
+
 ```csharp
 var meshes = new[] { mesh1, mesh2, mesh3 };
-var merged = PolyMesh.Group(meshes); // requires matching attribute sets
+var grouping = meshes.Group();
+if (!grouping.Valid)
+    throw new InvalidOperationException("Meshes have incompatible attributes.");
+
+var merged = grouping.Mesh;
 ```
+
+`Mesh` assumes a valid grouping and preserves the order in which meshes first occur, followed by selected face order within each mesh. Calling `Group()` on a face sequence merges only those faces and compacts their referenced vertices and indexed attribute values. Source meshes and attribute arrays are not mutated.
 
 ### Cleanup
 
@@ -230,8 +238,8 @@ var normalIndices = new int[] { 0, 0, 0, 1, 1, 1, 2, 2, 2 }; // 3 triangles
 
 mesh.FaceVertexAttributes = new SymbolDict<Array>
 {
-    [PolyMesh.Property.Normals] = normalData,
-    [-PolyMesh.Property.Normals] = normalIndices // negative key
+    [PolyMesh.Property.Normals] = normalIndices,
+    [-PolyMesh.Property.Normals] = normalData
 };
 ```
 
@@ -249,8 +257,8 @@ mesh.FaceAttributes[MyTemperature] = new float[] { 20.0f, 21.0f };
 // Per-face-vertex (indexed)
 var temps = new float[] { 15f, 20f, 25f };
 var tempIndices = new int[] { 0, 1, 2, 1, 2, 0 };
-mesh.FaceVertexAttributes[MyTemperature] = temps;
-mesh.FaceVertexAttributes[-MyTemperature] = tempIndices;
+mesh.FaceVertexAttributes[MyTemperature] = tempIndices;
+mesh.FaceVertexAttributes[-MyTemperature] = temps;
 ```
 
 ## Gotchas
@@ -258,12 +266,12 @@ mesh.FaceVertexAttributes[-MyTemperature] = tempIndices;
 1. **Shallow copy by default** - `new PolyMesh(other)` shares arrays. Mutate carefully.
 2. **Cached attributes don't update** - `Transformed()` updates positions/normals but cached derived data (areas, volumes) may be stale.
 3. **Topology not automatic** - Call `BuildTopology()` before accessing `Edges`, `Vertices.OutgoingEdges`, etc.
-4. **Indexed attributes require both arrays** - Set data array with positive key, index array with negative key.
+4. **Indexed attributes require both arrays** - The positive semantic key stores the `int[]` index array; its negative key stores the typed value array.
 5. **Triangulation is expensive** - Check `FaceVertexCountRange.Max` before calling `TriangulatedCopy()`.
 6. **Imported meshes have degenerate faces** - Call `WithoutDegeneratedFaces()` before processing.
 7. **Vertex clustering can throw** - Use try-catch when clustering with small delta values.
 8. **SubSetOfFaces compactVertices flag** - `true` reindexes vertices, `false` preserves original indices.
-9. **Group() requires matching attributes** - All meshes must have same attribute keys or operation fails.
+9. **Group() requires matching attributes** - Check `Group().Valid` before reading `Mesh`; incompatible groupings are descriptors but cannot be materialized safely.
 10. **FaceReversedCopy() blindly flips** - Analyze orientation first (check normals vs face winding), don't flip unnecessarily.
 
 ## See Also

--- a/src/Aardvark.Algodat.Tests/PolyMesh/PolyMeshGrouping.cs
+++ b/src/Aardvark.Algodat.Tests/PolyMesh/PolyMeshGrouping.cs
@@ -3,42 +3,330 @@ using NUnit.Framework;
 using NUnit.Framework.Legacy;
 using System;
 using System.Collections.Generic;
-using System.Text;
+using System.Linq;
 
 namespace Aardvark.Geometry.Tests
 {
     [TestFixture]
     public class PolyMeshGrouping
     {
+        private static readonly Symbol FaceValue = "GroupingFaceValue";
+        private static readonly Symbol VertexValue = "GroupingVertexValue";
+        private static readonly Symbol FaceVertexValue = "GroupingFaceVertexValue";
+
+        private enum AttributeRepresentation
+        {
+            Direct,
+            Indexed,
+        }
+
+        private sealed class MeshSnapshot
+        {
+            private readonly int[] m_firstIndexArray;
+            private readonly int[] m_firstIndexValues;
+            private readonly int[] m_vertexIndexArray;
+            private readonly int[] m_vertexIndexValues;
+            private readonly Dictionary<Symbol, (Array Reference, Array Values)> m_faceAttributes;
+            private readonly Dictionary<Symbol, (Array Reference, Array Values)> m_vertexAttributes;
+            private readonly Dictionary<Symbol, (Array Reference, Array Values)> m_faceVertexAttributes;
+
+            public MeshSnapshot(PolyMesh mesh)
+            {
+                m_firstIndexArray = mesh.FirstIndexArray;
+                m_firstIndexValues = (int[])m_firstIndexArray.Clone();
+                m_vertexIndexArray = mesh.VertexIndexArray;
+                m_vertexIndexValues = (int[])m_vertexIndexArray.Clone();
+                m_faceAttributes = Capture(mesh.FaceAttributes);
+                m_vertexAttributes = Capture(mesh.VertexAttributes);
+                m_faceVertexAttributes = Capture(mesh.FaceVertexAttributes);
+            }
+
+            private static Dictionary<Symbol, (Array Reference, Array Values)> Capture(SymbolDict<Array> attributes)
+                => attributes.ToDictionary(kvp => kvp.Key, kvp => (kvp.Value, (Array)kvp.Value.Clone()));
+
+            private static void AssertUnchanged(
+                SymbolDict<Array> attributes,
+                Dictionary<Symbol, (Array Reference, Array Values)> snapshot)
+            {
+                ClassicAssert.AreEqual(snapshot.Count, attributes.Count);
+                foreach (var kvp in snapshot)
+                {
+                    ClassicAssert.IsTrue(attributes.TryGetValue(kvp.Key, out var current));
+                    ClassicAssert.AreSame(kvp.Value.Reference, current);
+                    CollectionAssert.AreEqual(kvp.Value.Values, current);
+                }
+            }
+
+            public void AssertUnchanged(PolyMesh mesh)
+            {
+                ClassicAssert.AreSame(m_firstIndexArray, mesh.FirstIndexArray);
+                ClassicAssert.AreSame(m_vertexIndexArray, mesh.VertexIndexArray);
+                CollectionAssert.AreEqual(m_firstIndexValues, mesh.FirstIndexArray);
+                CollectionAssert.AreEqual(m_vertexIndexValues, mesh.VertexIndexArray);
+                AssertUnchanged(mesh.FaceAttributes, m_faceAttributes);
+                AssertUnchanged(mesh.VertexAttributes, m_vertexAttributes);
+                AssertUnchanged(mesh.FaceVertexAttributes, m_faceVertexAttributes);
+            }
+        }
+
         [Test]
-        [Ignore("@lui: please fix or remove.")]
-        public void TestPolyMeshGrouping()
+        public void GroupPreservesDirectConeFaceVertexNormals()
         {
             var mesh = PolyMeshPrimitives.Cone(12, 1, 0.5, C4b.Red);
-
-            // NOTE: mesh has FaceVertexNormals (non-indexed)
             ValidateNormals(mesh);
 
             var grouping = mesh.IntoArray().Group();
+            ClassicAssert.IsTrue(grouping.Valid);
 
-            var meshWithBrokenFaceVertexAttributes = grouping.Mesh; // normal array broken
-
-            // NOTE: grouped mesh will also have non-indexed FaceVertexNormals, but half of the data is "zero"
-            ValidateNormals(meshWithBrokenFaceVertexAttributes);
+            ValidateNormals(grouping.Mesh);
         }
 
-        static void ValidateNormals(PolyMesh mesh)
+        [Test]
+        public void GroupProjectsDirectAttributesFromReorderedFaceSubsets()
+            => AssertGroupedAttributes(AttributeRepresentation.Direct, AttributeRepresentation.Direct);
+
+        [Test]
+        public void GroupProjectsIndexedAttributesFromReorderedFaceSubsets()
+            => AssertGroupedAttributes(AttributeRepresentation.Indexed, AttributeRepresentation.Indexed);
+
+        [Test]
+        public void GroupProjectsMixedAttributesFromOriginalSelectedElements()
+            => AssertGroupedAttributes(AttributeRepresentation.Direct, AttributeRepresentation.Indexed);
+
+        private static void AssertGroupedAttributes(
+            AttributeRepresentation meshBRepresentation,
+            AttributeRepresentation meshARepresentation)
         {
-            mesh.Faces.ForEach(f =>
+            var meshA = CreateMesh(1, meshARepresentation);
+            var meshB = CreateMesh(2, meshBRepresentation);
+            var snapshotA = new MeshSnapshot(meshA);
+            var snapshotB = new MeshSnapshot(meshB);
+
+            var selectedFaces = new[]
             {
-                var fn = f.Polygon3d.ComputeNormal();
-                for (int i = 0; i < f.VertexCount; i++)
+                meshB.GetFace(2), meshA.GetFace(3), meshB.GetFace(0), meshA.GetFace(1)
+            };
+            var expectedFaces = new[]
+            {
+                meshB.GetFace(2), meshB.GetFace(0), meshA.GetFace(3), meshA.GetFace(1)
+            };
+            var expectedVertices = new[]
+            {
+                meshB.GetVertex(4), meshB.GetVertex(5), meshB.GetVertex(0), meshB.GetVertex(2), meshB.GetVertex(1),
+                meshA.GetVertex(6), meshA.GetVertex(7), meshA.GetVertex(1), meshA.GetVertex(0),
+                meshA.GetVertex(2), meshA.GetVertex(3), meshA.GetVertex(4), meshA.GetVertex(5)
+            };
+
+            var grouping = selectedFaces.Group();
+
+            ClassicAssert.IsTrue(grouping.Valid);
+            ClassicAssert.AreEqual(2, grouping.MeshCount);
+            CollectionAssert.AreEqual(new[] { meshB, meshA }, grouping.Meshes.ToArray());
+            CollectionAssert.AreEqual(new[] { meshB, meshA }, grouping.MatchingMeshes.ToArray());
+
+            var grouped = grouping.Mesh;
+            var outputIsIndexed = meshBRepresentation == AttributeRepresentation.Indexed
+                               || meshARepresentation == AttributeRepresentation.Indexed;
+
+            ClassicAssert.AreEqual(4, grouped.FaceCount);
+            ClassicAssert.AreEqual(13, grouped.VertexCount);
+            CollectionAssert.AreEqual(new[] { 0, 4, 7, 11, 15 }, grouped.FirstIndexArray);
+            CollectionAssert.AreEqual(
+                new[] { 0, 1, 2, 3, 2, 4, 3, 5, 6, 7, 8, 9, 10, 11, 12 },
+                grouped.VertexIndexArray);
+            CollectionAssert.AreEqual(expectedVertices.Select(v => v.Position), grouped.PositionArray);
+
+            var expectedFaceValues = expectedFaces.Select(GetFaceValue).ToArray();
+            var expectedVertexValues = expectedVertices.Select(GetVertexValue).ToArray();
+            var expectedFaceVertexValues = expectedFaces
+                .SelectMany(face => Enumerable.Range(0, face.VertexCount)
+                    .Select(side => GetFaceVertexValue(face, side)))
+                .ToArray();
+
+            for (var fi = 0; fi < grouped.FaceCount; fi++)
+            {
+                var actualFace = grouped.GetFace(fi);
+                var expectedFace = expectedFaces[fi];
+                CollectionAssert.AreEqual(
+                    expectedFace.Vertices.Select(v => v.Position),
+                    actualFace.Vertices.Select(v => v.Position));
+                ClassicAssert.AreEqual(
+                    expectedFaceValues[fi],
+                    outputIsIndexed
+                        ? actualFace.GetIndexedAttribute<string>(FaceValue)
+                        : actualFace.GetAttribute<string>(FaceValue));
+
+                for (var side = 0; side < actualFace.VertexCount; side++)
                 {
-                    // check if face vertex normal points in similar direction
-                    var fvn = f.GetVertexAttribute<V3d>(PolyMesh.Property.Normals, 0);
-                    ClassicAssert.True(fvn.Dot(fn) > 0);
+                    var expected = GetFaceVertexValue(expectedFace, side);
+                    var actual = outputIsIndexed
+                        ? actualFace.GetVertexIndexedAttribute<V2d>(FaceVertexValue, side)
+                        : actualFace.GetVertexAttribute<V2d>(FaceVertexValue, side);
+                    ClassicAssert.AreEqual(expected, actual);
                 }
-            });
+            }
+
+            for (var vi = 0; vi < grouped.VertexCount; vi++)
+            {
+                var actual = outputIsIndexed
+                    ? grouped.GetVertex(vi).GetIndexedAttribute<double>(VertexValue)
+                    : grouped.GetVertex(vi).GetAttribute<double>(VertexValue);
+                ClassicAssert.AreEqual(expectedVertexValues[vi], actual);
+            }
+
+            if (outputIsIndexed)
+            {
+                AssertCompactIndexedAttribute(grouped.FaceAttributes, FaceValue, expectedFaceValues);
+                AssertCompactIndexedAttribute(grouped.VertexAttributes, VertexValue, expectedVertexValues);
+                AssertCompactIndexedAttribute(grouped.FaceVertexAttributes, FaceVertexValue, expectedFaceVertexValues);
+            }
+            else
+            {
+                AssertDirectAttribute(grouped.FaceAttributes, FaceValue, expectedFaceValues);
+                AssertDirectAttribute(grouped.VertexAttributes, VertexValue, expectedVertexValues);
+                AssertDirectAttribute(grouped.FaceVertexAttributes, FaceVertexValue, expectedFaceVertexValues);
+            }
+
+            snapshotA.AssertUnchanged(meshA);
+            snapshotB.AssertUnchanged(meshB);
+        }
+
+        private static PolyMesh CreateMesh(int meshId, AttributeRepresentation representation)
+        {
+            int[] firstIndices;
+            int[] vertexIndices;
+            if (meshId == 1)
+            {
+                firstIndices = new[] { 0, 3, 7, 10, 14 };
+                vertexIndices = new[]
+                {
+                    0, 1, 2,
+                    2, 3, 4, 5,
+                    5, 6, 0,
+                    6, 7, 1, 0
+                };
+            }
+            else
+            {
+                firstIndices = new[] { 0, 3, 6, 10 };
+                vertexIndices = new[]
+                {
+                    0, 1, 2,
+                    2, 3, 4,
+                    4, 5, 0, 2
+                };
+            }
+
+            var vertexCount = vertexIndices.Max() + 1;
+            var positions = new V3d[vertexCount]
+                .SetByIndex(i => new V3d(meshId * 100 + i, meshId, -i));
+            var mesh = new PolyMesh
+            {
+                FirstIndexArray = firstIndices,
+                VertexIndexArray = vertexIndices,
+                PositionArray = positions,
+            };
+
+            var directFaces = new string[mesh.FaceCount]
+                .SetByIndex(i => $"mesh-{meshId}-face-{i}");
+            var directVertices = new double[mesh.VertexCount]
+                .SetByIndex(i => meshId * 1000.0 + i + 0.25);
+            var directFaceVertices = new V2d[mesh.VertexIndexArray.Length]
+                .SetByIndex(i => new V2d(meshId * 100 + i, -i - 0.5));
+
+            if (representation == AttributeRepresentation.Direct)
+            {
+                mesh.FaceAttributes[FaceValue] = directFaces;
+                mesh.VertexAttributes[VertexValue] = directVertices;
+                mesh.FaceVertexAttributes[FaceVertexValue] = directFaceVertices;
+            }
+            else
+            {
+                var faceValues = new string[3]
+                    .SetByIndex(i => $"mesh-{meshId}-indexed-face-{i}");
+                mesh.FaceAttributes[FaceValue] = new int[mesh.FaceCount]
+                    .SetByIndex(i => (i * 2 + meshId) % faceValues.Length);
+                mesh.FaceAttributes[-FaceValue] = faceValues;
+
+                var vertexValues = new double[4]
+                    .SetByIndex(i => meshId * 1000.0 + i * 10.0 + 0.5);
+                mesh.VertexAttributes[VertexValue] = new int[mesh.VertexCount]
+                    .SetByIndex(i => (i * 3 + meshId) % vertexValues.Length);
+                mesh.VertexAttributes[-VertexValue] = vertexValues;
+
+                var faceVertexValues = new V2d[5]
+                    .SetByIndex(i => new V2d(meshId * 100 + i * 10, -meshId - i));
+                mesh.FaceVertexAttributes[FaceVertexValue] = new int[mesh.VertexIndexArray.Length]
+                    .SetByIndex(i => (i * 2 + meshId) % faceVertexValues.Length);
+                mesh.FaceVertexAttributes[-FaceVertexValue] = faceVertexValues;
+            }
+
+            return mesh;
+        }
+
+        private static string GetFaceValue(PolyMesh.Face face)
+            => face.Mesh.FaceAttributes.Contains(-FaceValue)
+                ? face.GetIndexedAttribute<string>(FaceValue)
+                : face.GetAttribute<string>(FaceValue);
+
+        private static double GetVertexValue(PolyMesh.Vertex vertex)
+            => vertex.Mesh.VertexAttributes.Contains(-VertexValue)
+                ? vertex.GetIndexedAttribute<double>(VertexValue)
+                : vertex.GetAttribute<double>(VertexValue);
+
+        private static V2d GetFaceVertexValue(PolyMesh.Face face, int side)
+            => face.Mesh.FaceVertexAttributes.Contains(-FaceVertexValue)
+                ? face.GetVertexIndexedAttribute<V2d>(FaceVertexValue, side)
+                : face.GetVertexAttribute<V2d>(FaceVertexValue, side);
+
+        private static void AssertDirectAttribute<T>(
+            SymbolDict<Array> attributes,
+            Symbol name,
+            T[] expected)
+        {
+            ClassicAssert.AreEqual(typeof(T[]), attributes[name].GetType());
+            ClassicAssert.IsFalse(attributes.Contains(-name));
+            CollectionAssert.AreEqual(expected, (T[])attributes[name]);
+        }
+
+        private static void AssertCompactIndexedAttribute<T>(
+            SymbolDict<Array> attributes,
+            Symbol name,
+            T[] expected)
+        {
+            ClassicAssert.AreEqual(typeof(int[]), attributes[name].GetType());
+            ClassicAssert.AreEqual(typeof(T[]), attributes[-name].GetType());
+
+            var actualIndices = (int[])attributes[name];
+            var actualValues = (T[])attributes[-name];
+            var expectedIndices = new int[expected.Length];
+            var expectedValues = new List<T>();
+            for (var i = 0; i < expected.Length; i++)
+            {
+                var index = expectedValues.IndexOf(expected[i]);
+                if (index < 0)
+                {
+                    index = expectedValues.Count;
+                    expectedValues.Add(expected[i]);
+                }
+                expectedIndices[i] = index;
+            }
+
+            CollectionAssert.AreEqual(expectedIndices, actualIndices);
+            CollectionAssert.AreEqual(expectedValues, actualValues);
+        }
+
+        private static void ValidateNormals(PolyMesh mesh)
+        {
+            foreach (var face in mesh.Faces)
+            {
+                var faceNormal = face.Polygon3d.ComputeNormal();
+                for (var side = 0; side < face.VertexCount; side++)
+                {
+                    var faceVertexNormal = face.GetVertexAttribute<V3d>(PolyMesh.Property.Normals, side);
+                    ClassicAssert.Greater(faceVertexNormal.Dot(faceNormal), 0.0);
+                }
+            }
         }
     }
 }

--- a/src/Aardvark.Geometry.PolyMesh/PolyMeshGrouping.cs
+++ b/src/Aardvark.Geometry.PolyMesh/PolyMeshGrouping.cs
@@ -58,6 +58,10 @@ namespace Aardvark.Geometry
             public SymbolDict<IAttributeArray> FaceVertexAttributeArrays;
             public IEnumerable<IGrouping<PolyMesh, Face>> Groups;
 
+            /// <summary>
+            /// Indicates whether all grouped meshes have compatible instance, face, vertex,
+            /// and face-vertex attributes and can be materialized through <see cref="Mesh"/>.
+            /// </summary>
             public bool Valid
             {
                 get
@@ -80,6 +84,10 @@ namespace Aardvark.Geometry
                 }
             }
 
+            /// <summary>
+            /// Materializes the grouped faces in first-mesh and selected-face order.
+            /// Callers must check <see cref="Valid"/> before accessing this property.
+            /// </summary>
             public PolyMesh Mesh
             {
                 get
@@ -209,7 +217,7 @@ namespace Aardvark.Geometry
                                 else
                                 {
                                     for (int fi = 0; fi < fbm.Length; fi++)
-                                        afm[fi] = ac++;
+                                        afm.ForwardMapAdd(fbm[fi], ref ac);
                                 }
                                 afma[mi] = afm;
                             }
@@ -224,13 +232,13 @@ namespace Aardvark.Geometry
                                 var fo = foa[mi];
                                 if (mia != null)
                                 {
-                                    for (int fi = 0; fi < fbma.Length; fi++)
+                                    for (int fi = 0; fi < fbm.Length; fi++)
                                         indexArray[fo + fi] = afm[mia[fbm[fi]]];
                                 }
                                 else
                                 {
-                                    for (int fi = 0; fi < fbma.Length; fi++)
-                                        indexArray[fo + fi] = afm[fi];
+                                    for (int fi = 0; fi < fbm.Length; fi++)
+                                        indexArray[fo + fi] = afm[fbm[fi]];
                                 }
                                 aa[mi].ForwardMappedCopyTo(afm, valueArray, 0);
                             }
@@ -269,7 +277,7 @@ namespace Aardvark.Geometry
                                 else
                                 {
                                     for (int vi = 0; vi < vbm.Length; vi++)
-                                        afm[vi] = ac++;
+                                        afm.ForwardMapAdd(vbm[vi], ref ac);
                                 }
                                 afma[mi] = afm;
                             }
@@ -289,8 +297,8 @@ namespace Aardvark.Geometry
                                 }
                                 else
                                 {
-                                    for (int vi = 0; vi < vbma.Length; vi++)
-                                        indexArray[vo + vi] = afm[vi];
+                                    for (int vi = 0; vi < vbm.Length; vi++)
+                                        indexArray[vo + vi] = afm[vbm[vi]];
                                 }
                                 aa[mi].ForwardMappedCopyTo(afm, valueArray, 0);
                             }
@@ -310,7 +318,7 @@ namespace Aardvark.Geometry
                             var va = Array.CreateInstance(kvp.Value.Type, vic);
                             for (int mi = 0; mi < mc; mi++)
                                 aa[mi].BackMappedGroupCopyTo(
-                                        fbma[mi], fc, ma[mi].VertexIndexArray, va, fvoa[mi]);
+                                        fbma[mi], fbma[mi].Length, ma[mi].FirstIndexArray, va, fvoa[mi]);
                             faceVertexAttributes[kvp.Key] = va;
                         }
                         else
@@ -322,7 +330,6 @@ namespace Aardvark.Geometry
                                 var mia = aa[mi].IndexArray;
                                 var afm = new int[aa[mi].ValueArray.Length].Set(-1);
                                 var fbm = fbma[mi];
-                                var fvo = fvoa[mi];
                                 var mfia = ma[mi].FirstIndexArray;
                                 if (mia != null)
                                 {
@@ -336,9 +343,13 @@ namespace Aardvark.Geometry
                                 }
                                 else
                                 {
-                                    var fve = fvoa[mi + 1];
-                                    for (int fvi = 0; fvo < fve; fvo++, fvi++)
-                                        afm[fvi] = fvo;
+                                    for (int fi = 0; fi < fbm.Length; fi++)
+                                    {
+                                        var ofi = fbm[fi];
+                                        int ofvi = mfia[ofi], ofve = mfia[ofi + 1];
+                                        while (ofvi < ofve)
+                                            afm.ForwardMapAdd(ofvi++, ref ac);
+                                    }
                                 }
                                 afma[mi] = afm;
                             }
@@ -364,9 +375,13 @@ namespace Aardvark.Geometry
                                 }
                                 else
                                 {
-                                    var fve = fvoa[mi + 1];
-                                    for (int fvi = 0; fvo < fve; fvo++, fvi++)
-                                        indexArray[fvo] = afm[fvi];
+                                    for (int fi = 0; fi < fbm.Length; fi++)
+                                    {
+                                        var ofi = fbm[fi];
+                                        int ofvi = mfia[ofi], ofve = mfia[ofi + 1];
+                                        while (ofvi < ofve)
+                                            indexArray[fvo++] = afm[ofvi++];
+                                    }
                                 }
                                 aa[mi].ForwardMappedCopyTo(afm, valueArray, 0);
                             }
@@ -394,12 +409,20 @@ namespace Aardvark.Geometry
 
     public static class PolyMeshGroupingExtensions
     {
+        /// <summary>
+        /// Creates a grouping descriptor for all faces of the supplied meshes.
+        /// Check <see cref="PolyMesh.Grouping.Valid"/> before materializing its mesh.
+        /// </summary>
         public static PolyMesh.Grouping Group(
                 this IEnumerable<PolyMesh> meshes, SymbolDict<object> defaultInstanceValues = null)
         {
             return Group(from m in meshes from f in m.Faces select f, defaultInstanceValues);
         }
 
+        /// <summary>
+        /// Creates a grouping descriptor for the selected faces, preserving first-mesh and per-mesh face order.
+        /// Check <see cref="PolyMesh.Grouping.Valid"/> before materializing its mesh.
+        /// </summary>
         public static PolyMesh.Grouping Group(
                 this IEnumerable<PolyMesh.Face> faces, SymbolDict<object> defaultInstanceValues = null)
         {


### PR DESCRIPTION
## Summary
- copy direct face-vertex attributes through each source mesh's `FirstIndexArray` and selected face count
- use per-mesh map lengths and selected original face/vertex indices for indexed projection
- compact mixed direct/indexed face-vertex values from selected original corner ranges and emit aligned indices
- preserve group order, source arrays, runtime attribute types, and all-direct fast paths
- replace the ignored cone-normal regression with deterministic direct, indexed, and mixed subset coverage
- document `Group().Valid`/`Mesh` behavior and the positive-index/negative-value attribute convention

## Performance
Warmed Release grouping benchmarks used identical output checksums before and after (median of seven runs):

| Workload | Before | After | Throughput | Allocations |
| --- | ---: | ---: | ---: | ---: |
| Direct, 1,024 faces | 1.395 ms | 1.401 ms | 734k → 731k faces/s | 442,304 B → 442,304 B |
| Indexed, 256 faces | 0.375 ms | 0.364 ms | 683k → 703k faces/s | 163,496 B → 163,496 B |

The direct path is unchanged within run variance (0.4%); the indexed workload improved 2.9%. No workload added allocations.

## Validation
- focused grouping suite: 4 passed, including the previously ignored regression
- complete Release suite: 446 passed, 1 existing skip
- complete Release solution build with warnings as errors: 0 warnings, 0 errors
- coverage includes multiple meshes, unequal face counts, reordered/noncontiguous subsets, topology, direct/indexed/mixed face, vertex, and face-vertex attributes, compact index/value arrays, runtime types, group order, and source immutability

Fixes #65.