### PR TITLE
Restore LruDictionary recency semantics

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,5 @@
+- [PointSet] restore LRU recency and replacement semantics in `LruDictionary` (#67)
+
 ### 5.6.3
 - Updated SharpCompress to 0.48.1 to address CVE-2026-44788
 

--- a/src/Aardvark.Algodat.Tests/LruDictionaryTests.cs
+++ b/src/Aardvark.Algodat.Tests/LruDictionaryTests.cs
@@ -17,6 +17,7 @@ using NUnit.Framework.Legacy;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -467,6 +468,170 @@ namespace Aardvark.Geometry.Tests
             ClassicAssert.IsTrue(removed.Contains(1));
             ClassicAssert.IsTrue(!removed.Contains(-1));
             ClassicAssert.IsTrue(a.Count == 0);
+        }
+
+        #endregion
+
+        #region LRU semantics
+
+        [Test]
+        public void AddReturnsInsertionStatusAndReplacementUpdatesTuple()
+        {
+            var cache = new LruDictionary<int, string>(5);
+            var removed = new List<(int Key, string Value, long Size, string Callback)>();
+
+            ClassicAssert.IsTrue(cache.Add(1, "one", 2, (k, v, s) => removed.Add((k, v, s, "old"))));
+            ClassicAssert.IsTrue(cache.Add(2, "two", 2, (k, v, s) => removed.Add((k, v, s, "two"))));
+            ClassicAssert.IsFalse(cache.Add(1, "ONE", 3, (k, v, s) => removed.Add((k, v, s, "new"))));
+
+            ClassicAssert.AreEqual(2, cache.Count);
+            ClassicAssert.AreEqual(5, cache.CurrentSize);
+            ClassicAssert.AreEqual("ONE", cache[1]);
+            ClassicAssert.IsEmpty(removed);
+            CollectionAssert.AreEqual(new[] { 1, 2 }, cache.Keys);
+
+            ClassicAssert.IsTrue(cache.Add(3, "three", 3));
+
+            ClassicAssert.AreEqual(1, cache.Count);
+            ClassicAssert.AreEqual(3, cache.CurrentSize);
+            CollectionAssert.AreEqual(new[] { 3 }, cache.Keys);
+            CollectionAssert.AreEqual(new[] { 2, 1 }, removed.Select(x => x.Key));
+            ClassicAssert.AreEqual((2, "two", 2L, "two"), removed[0]);
+            ClassicAssert.AreEqual((1, "ONE", 3L, "new"), removed[1]);
+            ClassicAssert.IsFalse(removed.Any(x => x.Callback == "old"));
+        }
+
+        [Test]
+        public void TryGetValueRefreshesRecencyBeforeCapacityEviction()
+        {
+            var cache = new LruDictionary<int, string>(3);
+            cache.Add(1, "one", 1);
+            cache.Add(2, "two", 1);
+            cache.Add(3, "three", 1);
+            CollectionAssert.AreEqual(new[] { 3, 2, 1 }, cache.Keys);
+
+            ClassicAssert.IsTrue(cache.TryGetValue(1, out var value));
+            ClassicAssert.AreEqual("one", value);
+            CollectionAssert.AreEqual(new[] { 1, 3, 2 }, cache.Keys);
+
+            cache.Add(4, "four", 1);
+            CollectionAssert.AreEqual(new[] { 4, 1, 3 }, cache.Keys);
+            ClassicAssert.IsFalse(cache.ContainsKey(2));
+        }
+
+        [Test]
+        public void ContainsKeyDoesNotRefreshRecency()
+        {
+            var cache = new LruDictionary<int, string>(3);
+            cache.Add(1, "one", 1);
+            cache.Add(2, "two", 1);
+            cache.Add(3, "three", 1);
+
+            ClassicAssert.IsTrue(cache.ContainsKey(1));
+            CollectionAssert.AreEqual(new[] { 3, 2, 1 }, cache.Keys);
+
+            cache.Add(4, "four", 1);
+            ClassicAssert.IsFalse(cache.ContainsKey(1));
+            CollectionAssert.AreEqual(new[] { 4, 3, 2 }, cache.Keys);
+        }
+
+        [Test]
+        public void IndexerAndGetOrCreateHitsRefreshRecency()
+        {
+            var cache = new LruDictionary<int, string>(3);
+            cache.Add(1, "one", 1);
+            cache.Add(2, "two", 1);
+            cache.Add(3, "three", 1);
+
+            ClassicAssert.AreEqual("one", cache[1]);
+            CollectionAssert.AreEqual(new[] { 1, 3, 2 }, cache.Keys);
+            cache.Add(4, "four", 1);
+            ClassicAssert.IsFalse(cache.ContainsKey(2));
+
+            var created = false;
+            ClassicAssert.AreEqual("three", cache.GetOrCreate(3, () => { created = true; return ("THREE", 1); }));
+            ClassicAssert.IsFalse(created);
+            CollectionAssert.AreEqual(new[] { 3, 4, 1 }, cache.Keys);
+
+            cache.Add(5, "five", 1);
+            ClassicAssert.IsFalse(cache.ContainsKey(1));
+            CollectionAssert.AreEqual(new[] { 5, 3, 4 }, cache.Keys);
+        }
+
+        [Test]
+        public void RemovePairRequiresExactCurrentValue()
+        {
+            var callbackCount = 0;
+            var cache = new LruDictionary<int, string>(2);
+            cache.Add(1, "one", 1, (k, v, s) => callbackCount++);
+            cache.Add(2, "two", 1, (k, v, s) => callbackCount++);
+            IDictionary<int, string> dictionary = cache;
+
+            ClassicAssert.IsFalse(dictionary.Remove(new KeyValuePair<int, string>(1, "ONE")));
+            ClassicAssert.AreEqual(0, callbackCount);
+            CollectionAssert.AreEqual(new[] { 2, 1 }, cache.Keys);
+
+            cache.Add(3, "three", 1);
+            ClassicAssert.IsFalse(cache.ContainsKey(1));
+            ClassicAssert.AreEqual(1, callbackCount);
+
+            ClassicAssert.IsTrue(dictionary.Remove(new KeyValuePair<int, string>(2, "two")));
+            ClassicAssert.AreEqual(2, callbackCount);
+            ClassicAssert.IsFalse(cache.ContainsKey(2));
+        }
+
+        [Test]
+        public void EvictionCallbacksRunOutsideLockAndClearDoesNotInvokeThem()
+        {
+            var cache = new LruDictionary<int, string>(1);
+            var callbackCompleted = false;
+            cache.Add(1, "one", 1, (k, v, s) =>
+            {
+                var lookup = Task.Run(() => cache.ContainsKey(2));
+                callbackCompleted = lookup.Wait(TimeSpan.FromSeconds(5)) && lookup.Result;
+            });
+
+            ClassicAssert.AreEqual("two", cache.GetOrCreate(2, () => ("two", 1)));
+            ClassicAssert.IsTrue(callbackCompleted);
+
+            var clearCallbackCount = 0;
+            cache.Add(3, "three", 1, (k, v, s) => clearCallbackCount++);
+            cache.Clear();
+            ClassicAssert.AreEqual(0, clearCallbackCount);
+            ClassicAssert.AreEqual(0, cache.Count);
+            ClassicAssert.AreEqual(0, cache.CurrentSize);
+        }
+
+        [Test]
+        public void ConcurrentOperationsPreserveStateInvariants()
+        {
+            const int capacity = 32;
+            var cache = new LruDictionary<int, int>(capacity);
+            var tasks = Enumerable.Range(0, 8).Select(worker => Task.Run(() =>
+            {
+                for (var i = 0; i < 50_000; i++)
+                {
+                    var key = (worker * 17 + i * 31) & 63;
+                    switch ((worker + i) & 3)
+                    {
+                        case 0: cache.Add(key, worker * 100_000 + i, 1); break;
+                        case 1: cache.TryGetValue(key, out _); break;
+                        case 2: cache.Remove(key, callOnRemove: false); break;
+                        default: cache.GetOrCreate(key, () => (worker * 100_000 + i, 1)); break;
+                    }
+                }
+            })).ToArray();
+
+            Task.WaitAll(tasks);
+
+            var keys = cache.Keys.ToArray();
+            var values = cache.Values.ToArray();
+            ClassicAssert.AreEqual(cache.Count, keys.Length);
+            ClassicAssert.AreEqual(cache.Count, values.Length);
+            ClassicAssert.AreEqual(cache.Count, keys.Distinct().Count());
+            ClassicAssert.AreEqual(cache.Count, cache.CurrentSize);
+            ClassicAssert.LessOrEqual(cache.CurrentSize, cache.MaxSize);
+            ClassicAssert.IsTrue(keys.All(cache.ContainsKey));
         }
 
         #endregion

--- a/src/Aardvark.Data.Points.Base/LruDictionary.cs
+++ b/src/Aardvark.Data.Points.Base/LruDictionary.cs
@@ -19,20 +19,27 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 
 namespace Aardvark.Base
 {
     /// <summary>
+    /// Thread-safe, size-bounded dictionary that evicts the least recently used entries.
+    /// Successful value retrieval and replacement refresh recency; membership checks do not.
     /// </summary>
     public class LruDictionary<K, V> : IDictionary<K, V>
     {
-        /// <summary></summary>
+        /// <summary>Maximum combined entry size retained by the dictionary.</summary>
         public readonly long MaxSize;
 
-        /// <summary></summary>
-        public long CurrentSize { get; private set; }
+        /// <summary>Gets the combined size of all currently retained entries.</summary>
+        public long CurrentSize
+        {
+            get { lock (m_k2e) return m_currentSize; }
+        }
 
         /// <summary>
+        /// Creates an empty dictionary with the supplied positive size limit.
         /// </summary>
         public LruDictionary(long maxSize)
         {
@@ -55,18 +62,21 @@ namespace Aardvark.Base
         private Entry? m_first = null;
         private Entry? m_last = null;
         private readonly Dictionary<K, Entry> m_k2e = [];
+        private long m_currentSize;
 
-        private void Unlink(Entry e)
+        private void UnlinkLocked(Entry e)
         {
             if (e.Prev != null) e.Prev.Next = e.Next; else m_first = e.Next;
             if (e.Next != null) e.Next.Prev = e.Prev; else m_last = e.Prev;
+            e.Prev = null;
+            e.Next = null;
         }
-        private void InsertAtFront(Entry e)
+
+        private void InsertAtFrontLocked(Entry e)
         {
             if (m_first != null)
             {
                 m_first.Prev = e;
-                e.Prev = null;
                 e.Next = m_first;
                 m_first = e;
             }
@@ -76,23 +86,86 @@ namespace Aardvark.Base
                 m_first = m_last = e;
             }
         }
-        private void RemoveLast()
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void TouchLocked(Entry e)
         {
-            Entry? removed = null;
-            lock (m_k2e)
+            var first = m_first;
+            if (ReferenceEquals(first, e)) return;
+
+            var previous = e.Prev!;
+            var next = e.Next;
+            previous.Next = next;
+            if (next != null) next.Prev = previous; else m_last = previous;
+
+            e.Prev = null;
+            e.Next = first;
+            first!.Prev = e;
+            m_first = e;
+        }
+
+        private Entry RemoveEntryLocked(Entry e)
+        {
+            if (!m_k2e.Remove(e.Key)) throw new InvalidOperationException();
+            UnlinkLocked(e);
+            m_currentSize -= e.Size;
+            return e;
+        }
+
+        private Entry? EvictLocked()
+        {
+            Entry? first = null;
+            Entry? last = null;
+            while (m_currentSize > MaxSize)
             {
-                if (CurrentSize <= MaxSize) return;
-                if (m_last == null) return;
-                removed = m_last;
-                m_k2e.Remove(removed.Key);
-                CurrentSize -= m_last.Size;
-                m_last = m_last.Prev;
-                if (m_last == null) throw new InvalidOperationException();
-                m_last.Next = null;
+                var e = RemoveEntryLocked(m_last ?? throw new InvalidOperationException());
+                if (e.OnRemove != null)
+                {
+                    if (last != null) last.Next = e; else first = e;
+                    last = e;
+                }
+            }
+            return first;
+        }
+
+        private bool AddOrUpdateLocked(
+            K key, V value, long size, Action<K, V, long>? onRemove,
+            out Entry? evicted)
+        {
+            bool added;
+            if (m_k2e.TryGetValue(key, out var e))
+            {
+                m_currentSize -= e.Size;
+                e.Value = value;
+                e.Size = size;
+                e.OnRemove = onRemove;
+                TouchLocked(e);
+                added = false;
+            }
+            else
+            {
+                e = new Entry(key, value, size, onRemove);
+                m_k2e.Add(key, e);
+                InsertAtFrontLocked(e);
+                added = true;
             }
 
-            removed.OnRemove?.Invoke(removed.Key, removed.Value, removed.Size);
+            m_currentSize += size;
+            evicted = EvictLocked();
+            return added;
         }
+
+        private static void InvokeRemovalCallbacks(Entry? entry)
+        {
+            while (entry != null)
+            {
+                var next = entry.Next;
+                entry.Next = null;
+                entry.OnRemove?.Invoke(entry.Key, entry.Value, entry.Size);
+                entry = next;
+            }
+        }
+
         private List<Entry> GetEntriesInOrder()
         {
             var es = new List<Entry>();
@@ -110,75 +183,50 @@ namespace Aardvark.Base
 
         #endregion
 
-        /// <summary>
-        /// </summary>
-        public int Count => m_k2e.Count;
+        /// <summary>Gets the number of currently retained entries.</summary>
+        public int Count
+        {
+            get { lock (m_k2e) return m_k2e.Count; }
+        }
 
         /// <summary>
-        /// Adds or refreshes key/value pair.
-        /// Returns true if key did not exist.
+        /// Adds a new entry or atomically replaces an existing entry's value, size, and removal callback,
+        /// moving it to the most-recently-used position. Returns true only when a new key was inserted.
+        /// Replacement does not invoke the previous callback. Capacity-eviction callbacks receive the
+        /// latest tuple and run after the dictionary state lock has been released.
         /// </summary>
         public bool Add(K key, V value, long size, Action<K, V, long>? onRemove = null)
         {
             if (size > MaxSize || size < 0) throw new ArgumentOutOfRangeException(nameof(size));
 
-            Entry? e = null;
+            bool added;
+            Entry? evicted;
             lock (m_k2e)
-            {
-                if (m_k2e.TryGetValue(key, out e))
-                {
-                    Unlink(e);
-                    CurrentSize -= e.Size; e.Size = size; 
-                }
-                else
-                {
-                    e = new Entry(key, value, size, onRemove);
-                    m_k2e[key] = e;
-                }
-                
-                InsertAtFront(e);
-                CurrentSize += e.Size;
-            }
-            
-            while (CurrentSize > MaxSize)
-            {
-                RemoveLast();
-            }
+                added = AddOrUpdateLocked(key, value, size, onRemove, out evicted);
 
-            return e == null;
+            InvokeRemovalCallbacks(evicted);
+            return added;
         }
 
         /// <summary>
-        /// Removes entry with given key, or nothing if key does not exist.
-        /// Returns true if entry did exist.
+        /// Removes the entry with the supplied key. Returns false when no such key exists.
+        /// If requested, invokes its current removal callback after releasing the state lock.
         /// </summary>
         public bool Remove(K key, bool callOnRemove)
         {
-            Entry? e = null;
-
+            Entry e;
             lock (m_k2e)
             {
-                if (m_k2e.TryGetValue(key, out e))
-                {
-                    m_k2e.Remove(key);
-                    if (e.Prev != null) e.Prev.Next = e.Next; else m_first = e.Next;
-                    if (e.Next != null) e.Next.Prev = e.Prev; else m_last = e.Prev;
-                    CurrentSize -= e.Size;
-                }
-                else
-                {
-                    return false;
-                }
+                if (!m_k2e.TryGetValue(key, out e)) return false;
+                RemoveEntryLocked(e);
             }
 
-            if (callOnRemove)
-            {
-                e.OnRemove?.Invoke(key, e.Value, e.Size);
-            }
+            if (callOnRemove) e.OnRemove?.Invoke(e.Key, e.Value, e.Size);
             return true;
         }
 
         /// <summary>
+        /// Tests membership without changing recency.
         /// </summary>
         public bool ContainsKey(K key)
         {
@@ -189,6 +237,8 @@ namespace Aardvark.Base
         }
 
         /// <summary>
+        /// Gets a value and moves a successful hit to the most-recently-used position.
+        /// Misses do not alter recency.
         /// </summary>
         public bool TryGetValue(K key, out V value)
         {
@@ -196,6 +246,7 @@ namespace Aardvark.Base
             {
                 if (m_k2e.TryGetValue(key, out Entry e))
                 {
+                    TouchLocked(e);
                     value = e.Value;
                     return true;
                 }
@@ -210,21 +261,34 @@ namespace Aardvark.Base
         }
 
         /// <summary>
+        /// Returns an existing value and refreshes its recency, or creates and inserts a value on a miss.
+        /// The factory may run concurrently for the same key; only the first inserted tuple is retained.
+        /// Capacity-eviction callbacks run after the state lock has been released.
         /// </summary>
         public V GetOrCreate(K key, Func<(V, long)> create, Action<K, V, long>? onRemove = null)
         {
             if (TryGetValue(key, out V value)) return value;
 
             var (createdValue, size) = create();
+            Entry? evicted;
             lock (m_k2e)
             {
-                if (TryGetValue(key, out V v)) return v;
-                Add(key, createdValue, size, onRemove);
-                return createdValue;
+                if (m_k2e.TryGetValue(key, out var e))
+                {
+                    TouchLocked(e);
+                    return e.Value;
+                }
+
+                if (size > MaxSize || size < 0) throw new ArgumentOutOfRangeException(nameof(size));
+                AddOrUpdateLocked(key, createdValue, size, onRemove, out evicted);
             }
+
+            InvokeRemovalCallbacks(evicted);
+            return createdValue;
         }
 
         /// <summary>
+        /// Removes all entries without invoking removal callbacks.
         /// </summary>
         public void Clear()
         {
@@ -233,7 +297,7 @@ namespace Aardvark.Base
                 m_k2e.Clear();
                 m_first = null;
                 m_last = null;
-                CurrentSize = 0;
+                m_currentSize = 0;
             }
         }
 
@@ -252,7 +316,7 @@ namespace Aardvark.Base
         /// <summary></summary>
         public bool IsReadOnly => false;
 
-        /// <summary></summary>
+        /// <summary>Gets a value and refreshes its recency. Setting is unsupported because entry size is required.</summary>
         public V this[K key]
         {
             get => TryGetValue(key, out V value) ? value : throw new KeyNotFoundException($"Key '{key}' not found. Use TryGetValue instead.");
@@ -268,18 +332,31 @@ namespace Aardvark.Base
         /// <summary></summary>
         public bool Remove(K key) => Remove(key, true);
 
-        /// <summary></summary>
-        public bool Remove(KeyValuePair<K, V> item) => Remove(item.Key, true);
+        /// <summary>
+        /// Removes an entry only when both its key and current value match, invoking its current callback outside the lock.
+        /// </summary>
+        public bool Remove(KeyValuePair<K, V> item)
+        {
+            Entry e;
+            lock (m_k2e)
+            {
+                if (!m_k2e.TryGetValue(item.Key, out e)) return false;
+                if (!EqualityComparer<V>.Default.Equals(e.Value, item.Value)) return false;
+                RemoveEntryLocked(e);
+            }
 
-        /// <summary></summary>
+            e.OnRemove?.Invoke(e.Key, e.Value, e.Size);
+            return true;
+        }
+
+        /// <summary>Tests for an exact key/value pair without changing recency.</summary>
         public bool Contains(KeyValuePair<K, V> item)
         {
-            if (TryGetValue(item.Key, out V value))
+            lock (m_k2e)
             {
-                if (item.Value != null) return item.Value.Equals(value);
-                else return value == null;
+                return m_k2e.TryGetValue(item.Key, out var e)
+                    && EqualityComparer<V>.Default.Equals(e.Value, item.Value);
             }
-            return false;
         }
 
         /// <summary></summary>


### PR DESCRIPTION
## Summary
- move successful `TryGetValue`, indexer, and `GetOrCreate` hits to the MRU head
- keep `ContainsKey` and pair membership checks non-touching
- atomically replace an existing entry's value, size, and callback while returning accurate insertion status
- consolidate unlink/removal/eviction under one state lock and publish consistent count/size snapshots
- invoke eviction callbacks after releasing the lock, using the latest tuple and no extra allocation when callbacks are absent
- require exact key/value matches for `Remove(KeyValuePair<,>)` and retain callback-free `Clear` behavior

## Performance
Warmed Release microbenchmarks used alternating process order and median results from eight runs; checksums matched throughout:

| Workload | Before | After | Change | Allocations |
| --- | ---: | ---: | ---: | ---: |
| Repeated MRU hits | 29.865 ns | 27.375 ns | 8.3% faster | 0 B/op → 0 B/op |
| 90/10 hot/mixed hits | 18.165 ns | 19.855 ns | 9.3% slower | 0 B/op → 0 B/op |
| Add/evict | 70.545 ns | 45.050 ns | 36.1% faster | 56 B/op → 56 B/op |

Mixed hits now perform the required linked-list recency update when the hit is not already MRU; the optimized touch remains allocation-free and adds 1.69 ns in this workload. The current-head fast path and add/evict path both improved.

## Validation
- focused cache suite: 38 passed
- complete Release suite: 449 passed, 2 existing skips
- complete Release solution build with warnings as errors: 0 warnings, 0 errors
- coverage includes insertion/replacement return values, tuple and callback replacement, read/indexer/GetOrCreate recency, non-touching membership, exact-pair removal, callback lock boundaries, Clear behavior, capacity eviction, and concurrent count/size/list invariants

Fixes #67.