### PR TITLE
Honor ASCII parser parallelism limits

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,5 @@
+- [ASCII] honor `MaxDegreeOfParallelism` when parsing input buffers (#69)
+
 ### 5.6.3
 - Updated SharpCompress to 0.48.1 to address CVE-2026-44788
 

--- a/ai/IMPORTERS.md
+++ b/ai/IMPORTERS.md
@@ -35,7 +35,9 @@ var pointset = PointCloud.Import(filename, config);
 var config = ImportConfig.Default
     .WithStorage(PointCloud.CreateInMemoryStore(cache: default))
     .WithKey("my-pointcloud")
-    .WithMaxChunkPointCount(65536)              // Chunk size control
+    .WithMaxDegreeOfParallelism(4)               // Parser/import worker limit; <= 0 uses the CPU count
+    .WithMaxChunkPointCount(65536)               // Point chunk sizing and merging
+    .WithReadBufferSizeInBytes(64 * 1024 * 1024) // Raw input buffer size (especially relevant to ASCII)
     .WithPartIndexOffset(42)                     // Multi-file tracking
     .WithEnabledPartIndices(true)                // Enable part indices
     .WithMinDist(0.01)                           // Point density filtering
@@ -155,6 +157,13 @@ var customChunks = Ascii.Chunks("scan.txt", customFormat.LineDefinition, ParseCo
 - Progress reporting and verbose logging
 - Null handling for missing colors/normals/intensities
 
+**Parallelism and sizing controls:**
+- `MaxDegreeOfParallelism` bounds concurrent ASCII buffer parsers. Values less than one retain the shared mapper default of `Environment.ProcessorCount`.
+- `ReadBufferSizeInBytes` controls the raw stream buffers split at newline boundaries and therefore the natural input granularity and per-parser memory footprint.
+- `MaxChunkPointCount` controls point chunk sizing or merging in importer stages that support it; it does not control ASCII parser worker concurrency.
+
+These settings are independent. For example, reducing `MaxChunkPointCount` does not serialize parsing, and increasing it does not create more parser workers.
+
 ### LAS/LAZ Format
 
 LiDAR data format (LAS 1.0-1.4) with optional compression (.laz).
@@ -246,17 +255,19 @@ var transformed = pointset.Transform(Matrix4x4.FromRotationZ(Math.PI / 2));
 
 **Problem:** Loading entire point clouds into memory can exhaust resources.
 
-**Solution:** Use chunked processing and configure `MaxChunkPointCount`:
+**Solution:** Use chunked processing and configure point chunk size separately from parser concurrency and raw input buffering:
 
 ```csharp
-var config = ImportConfig.Default
-    .WithMaxChunkPointCount(32768)  // Smaller chunks
-    .WithStorage(PointCloud.CreateInMemoryStore(cache: default));
+var lasConfig = ParseConfig.Default
+    .WithMaxChunkPointCount(32768); // Smaller LAS/LAZ point chunks
+foreach (var chunk in Laszip.Chunks("huge.laz", lasConfig))
+    ProcessChunk(chunk);
 
-foreach (var chunk in Laszip.Chunks("huge.laz", ParseConfig.Default))
-{
-    ProcessChunk(chunk);  // Process one chunk at a time
-}
+var asciiConfig = ParseConfig.Default
+    .WithMaxDegreeOfParallelism(4)               // At most four ASCII buffer parsers
+    .WithReadBufferSizeInBytes(32 * 1024 * 1024); // Smaller raw ASCII buffers
+foreach (var chunk in Pts.Chunks("huge.pts", asciiConfig))
+    ProcessChunk(chunk);
 ```
 
 ### 3. Missing Properties Are Null

--- a/src/Aardvark.Algodat.Tests/ParsingTests.cs
+++ b/src/Aardvark.Algodat.Tests/ParsingTests.cs
@@ -16,10 +16,12 @@ using Aardvark.Data.Points;
 using NUnit.Framework;
 using NUnit.Framework.Legacy;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using static Aardvark.Data.Points.Import.Ascii;
 
 namespace Aardvark.Geometry.Tests
@@ -97,6 +99,147 @@ namespace Aardvark.Geometry.Tests
 
         #region ParseBuffers
 
+        private static readonly TimeSpan s_synchronizationTimeout = TimeSpan.FromSeconds(15);
+
+        private static IEnumerable<Aardvark.Data.Points.Buffer> CreateNumberedBuffers(int count)
+        {
+            for (var i = 0; i < count; i++)
+                yield return Aardvark.Data.Points.Buffer.Create(new[] { (byte)i }, 0, 1);
+        }
+
+        private static void UpdatePeak(ref int peak, int value)
+        {
+            var current = Volatile.Read(ref peak);
+            while (value > current)
+            {
+                var previous = Interlocked.CompareExchange(ref peak, value, current);
+                if (previous == current) return;
+                current = previous;
+            }
+        }
+
+        private static (Chunk[] Chunks, int Peak) RunSynchronizedParse(
+            int bufferCount, int maxDegreeOfParallelism, int maxChunkPointCount)
+        {
+            var expectedParallelism = Math.Min(
+                bufferCount,
+                maxDegreeOfParallelism > 0 ? maxDegreeOfParallelism : Environment.ProcessorCount);
+            using var entered = new CountdownEvent(expectedParallelism);
+            using var release = new ManualResetEventSlim(false);
+            var active = 0;
+            var peak = 0;
+            var started = 0;
+
+            Chunk Parse(byte[] data, int count, double minDist, int? partIndex)
+            {
+                var current = Interlocked.Increment(ref active);
+                UpdatePeak(ref peak, current);
+                var invocation = Interlocked.Increment(ref started);
+                if (invocation <= expectedParallelism) entered.Signal();
+                try
+                {
+                    release.Wait();
+                    return new Chunk(new[] { new V3d(data[0], 0.0, 0.0) });
+                }
+                finally
+                {
+                    Interlocked.Decrement(ref active);
+                }
+            }
+
+            var config = ParseConfig.Default
+                .WithMaxDegreeOfParallelism(maxDegreeOfParallelism)
+                .WithMaxChunkPointCount(maxChunkPointCount)
+                .WithVerbose(false);
+            var parseTask = Task.Run(() => CreateNumberedBuffers(bufferCount)
+                .ParseBuffers(bufferCount, Parse, config)
+                .ToArray());
+
+            var reachedConfiguredParallelism = false;
+            var activeWhileBlocked = 0;
+            try
+            {
+                reachedConfiguredParallelism = entered.Wait(s_synchronizationTimeout);
+                activeWhileBlocked = Volatile.Read(ref active);
+            }
+            finally
+            {
+                release.Set();
+            }
+
+            ClassicAssert.IsTrue(
+                parseTask.Wait(s_synchronizationTimeout),
+                "Synchronized ParseBuffers run did not complete.");
+            ClassicAssert.IsTrue(
+                reachedConfiguredParallelism,
+                $"Expected {expectedParallelism} parsers to overlap, but observed {activeWhileBlocked}.");
+            ClassicAssert.AreEqual(expectedParallelism, activeWhileBlocked);
+            ClassicAssert.LessOrEqual(peak, expectedParallelism);
+
+            var chunks = parseTask.Result;
+            ClassicAssert.AreEqual(bufferCount, chunks.Length);
+            CollectionAssert.AreEqual(
+                Enumerable.Range(0, bufferCount),
+                chunks.SelectMany(x => x.Positions).Select(p => (int)p.X).OrderBy(x => x));
+            return (chunks, peak);
+        }
+
+        [Test]
+        public void ParseBuffers_DegreeOfOnePreventsParserOverlap()
+        {
+            var result = RunSynchronizedParse(
+                bufferCount: 8,
+                maxDegreeOfParallelism: 1,
+                maxChunkPointCount: 128);
+
+            ClassicAssert.AreEqual(1, result.Peak);
+        }
+
+        [Test]
+        public void ParseBuffers_ConfiguredDegreeAllowsButBoundsParserOverlap()
+        {
+            var result = RunSynchronizedParse(
+                bufferCount: 16,
+                maxDegreeOfParallelism: 3,
+                maxChunkPointCount: 128);
+
+            ClassicAssert.AreEqual(3, result.Peak);
+        }
+
+        [Test]
+        public void ParseBuffers_MaxChunkPointCountDoesNotControlParserConcurrency()
+        {
+            var result = RunSynchronizedParse(
+                bufferCount: 8,
+                maxDegreeOfParallelism: 2,
+                maxChunkPointCount: 1);
+
+            ClassicAssert.AreEqual(2, result.Peak);
+        }
+
+        [Test]
+        public void ParseBuffers_ParallelCompletionReturnsEveryOutputExactlyOnce()
+        {
+            var result = RunSynchronizedParse(
+                bufferCount: 64,
+                maxDegreeOfParallelism: 4,
+                maxChunkPointCount: 97);
+
+            ClassicAssert.AreEqual(64, result.Chunks.Sum(x => x.Count));
+        }
+
+        [TestCase(0)]
+        [TestCase(-1)]
+        public void ParseBuffers_NonPositiveDegreeUsesMapParallelDefault(int configuredDegree)
+        {
+            var result = RunSynchronizedParse(
+                bufferCount: 4,
+                maxDegreeOfParallelism: configuredDegree,
+                maxChunkPointCount: 1);
+
+            ClassicAssert.AreEqual(Math.Min(Environment.ProcessorCount, 4), result.Peak);
+        }
+
         [Test]
         public void ParseBuffers_Works()
         {
@@ -110,7 +253,7 @@ namespace Aardvark.Geometry.Tests
                 .ChunkStreamAtNewlines(10, 5, CancellationToken.None)
                 .ParseBuffers(buffer.LongLength, parse, config)
                 .ToArray();
-            ClassicAssert.IsTrue(xs != null);
+            ClassicAssert.AreEqual(4, xs.Length);
         }
 
         #endregion

--- a/src/Aardvark.Data.Points.Ascii/Parsing.cs
+++ b/src/Aardvark.Data.Points.Ascii/Parsing.cs
@@ -162,7 +162,7 @@ namespace Aardvark.Data.Points
 
                         return r;
                     },
-                    config.MaxChunkPointCount,
+                    config.MaxDegreeOfParallelism,
                     elapsed =>
                     {
                         if (config.Verbose)


### PR DESCRIPTION
## Summary
- pass `ParseConfig.MaxDegreeOfParallelism` to the ASCII `ParseBuffers` worker mapper
- preserve the mapper's processor-count default for zero and negative values
- keep point-chunk sizing and raw read-buffer sizing independent from parser concurrency
- add synchronization-based regressions for serial execution, bounded overlap, chunk-size independence, non-positive defaults, and exactly-once output delivery
- document the three separate import controls and their memory implications

## Regression coverage
The tests hold parser calls behind synchronization gates and inspect concurrent entry counts without sleep-based assertions. Against the previous implementation, the chunk-size-independence regression deterministically reported one active parser when two were configured. With this change, configured degrees of one, two, three, and four are observed exactly and never exceeded; every numbered output is returned once.

## Performance
Warmed Release parsing of 1,048,576 XYZRGB records used four workers before and after. Medians from nine runs:

| Metric | Before | After |
| --- | ---: | ---: |
| Throughput | 82.853 MiB/s | 83.169 MiB/s |
| Allocations | 584.361 MiB | 584.357 MiB |
| Peak in-flight parsers | 4 | 4 |

Checksums matched. Throughput improved 0.4%, allocations were effectively unchanged, and peak parser activity matched the configured bound.

## Validation
- 35 focused parsing tests passed
- 448 complete-suite tests passed with 2 existing skips
- complete Release solution build passed with warnings treated as errors

Fixes #69.