### PR TITLE
Repair LineSet ray intersection semantics

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,5 @@
+- [Geometry] repair `LineSet` indexed bounds and nearest ray intersections (#71)
+
 ### 5.6.3
 - Updated SharpCompress to 0.48.1 to address CVE-2026-44788
 

--- a/ai/GEOMETRY.md
+++ b/ai/GEOMETRY.md
@@ -97,6 +97,7 @@ Kd-tree–based ray-object intersection with custom object sets.
 | `IIntersectableObjectSet` | Interface for ray-intersectable object collections |
 | `KdIntersectionTree` | Kd-tree accelerating ray intersections and closest-point queries |
 | `IntersectableTriangleSet` | Triangle soup implementation of `IIntersectableObjectSet` |
+| `LineSet` | Finite cylinders exposed as ray-intersectable line objects |
 | `ObjectRayHit` | Ray intersection result with t-parameter, point, and object reference |
 | `ObjectClosestPoint` | Closest-point query result with distance and coordinates |
 | `FastRay3d` | Precomputed ray data for efficient kd-tree traversal |
@@ -129,6 +130,14 @@ if (kdTree.ClosestPoint(queryPoint, ref closest))
     double distance = closest.Distance;
 }
 ```
+
+### LineSet ray-query semantics
+
+`LineSet` treats each `Cylinder3d` as one object. `ObjectBoundingBox()` returns aggregate bounds, while `ObjectBoundingBox(index)` returns only the selected cylinder's bounds.
+
+`ObjectsIntersectRay` evaluates exactly `objectIndexArray[firstIndex .. firstIndex + indexCount]` and returns the nearest accepted cylinder regardless of index order. The effective upper bound is the smaller of `tmax` and the incoming `hit.RayHit.T`, and candidates must be strictly closer than that bound. Rejected candidates do not tighten it, so a rejected near hit cannot hide an accepted farther hit. If no candidate is accepted, the complete incoming `ObjectRayHit` remains unchanged.
+
+A non-null object filter returns `true` to include a cylinder. For the historical LineSet hit-filter convention, `true` rejects a candidate and `false` accepts it. Passing a null object filter uses the dedicated allocation-free scan path.
 
 ### Gotchas
 

--- a/src/Aardvark.Algodat.Tests/LineSetTests.cs
+++ b/src/Aardvark.Algodat.Tests/LineSetTests.cs
@@ -1,0 +1,208 @@
+﻿/*
+    Copyright (C) 2006-2025. Aardvark Platform Team. http://github.com/aardvark-platform.
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+using Aardvark.Base;
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+using System.Collections.Generic;
+
+namespace Aardvark.Geometry.Tests
+{
+    [TestFixture]
+    public class LineSetTests
+    {
+        private static readonly FastRay3d s_ray = new(V3d.Zero, V3d.XAxis);
+
+        private static Cylinder3d CylinderAt(double x, double radius = 0.5)
+            => new(new V3d(x, -1.0, 0.0), new V3d(x, 1.0, 0.0), radius);
+
+        private static void AssertHit(ObjectRayHit hit, LineSet set, int index, double t)
+        {
+            ClassicAssert.AreSame(set, hit.SetObject.Set);
+            ClassicAssert.AreEqual(index, hit.SetObject.Index);
+            ClassicAssert.AreEqual(t, hit.RayHit.T, 1e-12);
+            ClassicAssert.IsTrue(hit.RayHit.Point.ApproximateEquals(s_ray.Ray.GetPointOnRay(t), 1e-12));
+        }
+
+        private static ObjectRayHit CreateSentinelHit(LineSet set, double cutoff, out object tag, out List<SetObject> stack)
+        {
+            tag = new object();
+            stack = new List<SetObject> { new(set, 17) };
+            var hit = new ObjectRayHit(cutoff)
+            {
+                SetObject = new SetObject(set, 23),
+                ObjectStack = stack,
+                Tag = tag
+            };
+            hit.RayHit.Point = new V3d(91, 92, 93);
+            hit.RayHit.Coord = new V2d(41, 42);
+            hit.RayHit.BackSide = true;
+            hit.RayHit.Part = 37;
+            return hit;
+        }
+
+        private static void AssertUnchanged(ObjectRayHit expected, ObjectRayHit actual, object tag, List<SetObject> stack)
+        {
+            ClassicAssert.AreEqual(expected.RayHit.T, actual.RayHit.T);
+            ClassicAssert.AreEqual(expected.RayHit.Point, actual.RayHit.Point);
+            ClassicAssert.AreEqual(expected.RayHit.Coord, actual.RayHit.Coord);
+            ClassicAssert.AreEqual(expected.RayHit.BackSide, actual.RayHit.BackSide);
+            ClassicAssert.AreEqual(expected.RayHit.Part, actual.RayHit.Part);
+            ClassicAssert.AreSame(expected.SetObject.Set, actual.SetObject.Set);
+            ClassicAssert.AreEqual(expected.SetObject.Index, actual.SetObject.Index);
+            ClassicAssert.AreSame(stack, actual.ObjectStack);
+            ClassicAssert.AreSame(tag, actual.Tag);
+        }
+
+        [Test]
+        public void ObjectBoundingBoxReturnsAggregateAndSelectedCylinderBounds()
+        {
+            var set = new LineSet(new[] { CylinderAt(3.0), CylinderAt(8.0) });
+
+            ClassicAssert.AreEqual(
+                new Box3d(new V3d(2.5, -1.0, -0.5), new V3d(8.5, 1.0, 0.5)),
+                set.ObjectBoundingBox());
+            ClassicAssert.AreEqual(
+                new Box3d(new V3d(2.5, -1.0, -0.5), new V3d(3.5, 1.0, 0.5)),
+                set.ObjectBoundingBox(0));
+            ClassicAssert.AreEqual(
+                new Box3d(new V3d(7.5, -1.0, -0.5), new V3d(8.5, 1.0, 0.5)),
+                set.ObjectBoundingBox(1));
+        }
+
+        [Test]
+        public void RayIntersectionReturnsNearestHitRegardlessOfIndexOrder()
+        {
+            var set = new LineSet(new[] { CylinderAt(8.0), CylinderAt(3.0), CylinderAt(5.0) });
+
+            foreach (var indices in new[] { new[] { 0, 2, 1 }, new[] { 1, 2, 0 } })
+            {
+                var hit = new ObjectRayHit(100.0);
+                var found = set.ObjectsIntersectRay(
+                    indices, 0, indices.Length, s_ray,
+                    objectFilter: null, hitFilter: null,
+                    tmin: 0.0, tmax: 100.0, ref hit);
+
+                ClassicAssert.IsTrue(found);
+                AssertHit(hit, set, index: 1, t: 2.5);
+            }
+        }
+
+        [Test]
+        public void NullObjectFilterInspectsOnlyRequestedIndexSlice()
+        {
+            var set = new LineSet(new[]
+            {
+                CylinderAt(2.0), CylinderAt(8.0), CylinderAt(5.0), CylinderAt(1.0)
+            });
+            var hit = new ObjectRayHit(100.0);
+
+            var found = set.ObjectsIntersectRay(
+                new[] { 0, 1, 2, 3 }, firstIndex: 1, indexCount: 2, s_ray,
+                objectFilter: null, hitFilter: null,
+                tmin: 0.0, tmax: 100.0, ref hit);
+
+            ClassicAssert.IsTrue(found);
+            AssertHit(hit, set, index: 2, t: 4.5);
+        }
+
+        [Test]
+        public void ObjectFilterInspectsOnlyRequestedSliceAndExcludesCandidates()
+        {
+            var set = new LineSet(new[]
+            {
+                CylinderAt(2.0), CylinderAt(8.0), CylinderAt(5.0), CylinderAt(1.0)
+            });
+            var inspected = new List<int>();
+            var hit = new ObjectRayHit(100.0);
+
+            var found = set.ObjectsIntersectRay(
+                new[] { 0, 1, 2, 3 }, firstIndex: 1, indexCount: 2, s_ray,
+                objectFilter: (_, index) => { inspected.Add(index); return index != 2; },
+                hitFilter: null,
+                tmin: 0.0, tmax: 100.0, ref hit);
+
+            ClassicAssert.IsTrue(found);
+            CollectionAssert.AreEqual(new[] { 1, 2 }, inspected);
+            AssertHit(hit, set, index: 1, t: 7.5);
+        }
+
+        [Test]
+        public void RejectedNearHitDoesNotHideAcceptedFarHit()
+        {
+            var set = new LineSet(new[] { CylinderAt(3.0), CylinderAt(8.0) });
+            var filtered = new List<int>();
+            var hit = new ObjectRayHit(100.0);
+
+            var found = set.ObjectsIntersectRay(
+                new[] { 0, 1 }, 0, 2, s_ray,
+                objectFilter: null,
+                hitFilter: (_, index, _, _) => { filtered.Add(index); return index == 0; },
+                tmin: 0.0, tmax: 100.0, ref hit);
+
+            ClassicAssert.IsTrue(found);
+            CollectionAssert.AreEqual(new[] { 0, 1 }, filtered);
+            AssertHit(hit, set, index: 1, t: 7.5);
+        }
+
+        [Test]
+        public void IncomingCutoffIsStrictAndPreservesPriorHit()
+        {
+            var set = new LineSet(new[] { CylinderAt(3.0) });
+            var hit = CreateSentinelHit(set, cutoff: 2.5, out var tag, out var stack);
+            var original = hit;
+
+            var found = set.ObjectsIntersectRay(
+                new[] { 0 }, 0, 1, s_ray,
+                objectFilter: null, hitFilter: null,
+                tmin: 0.0, tmax: 100.0, ref hit);
+
+            ClassicAssert.IsFalse(found);
+            AssertUnchanged(original, hit, tag, stack);
+        }
+
+        [Test]
+        public void RejectedHitsPreservePriorHitState()
+        {
+            var set = new LineSet(new[] { CylinderAt(3.0), CylinderAt(8.0) });
+            var hit = CreateSentinelHit(set, cutoff: 100.0, out var tag, out var stack);
+            var original = hit;
+
+            var found = set.ObjectsIntersectRay(
+                new[] { 0, 1 }, 0, 2, s_ray,
+                objectFilter: null,
+                hitFilter: (_, _, _, _) => true,
+                tmin: 0.0, tmax: 100.0, ref hit);
+
+            ClassicAssert.IsFalse(found);
+            AssertUnchanged(original, hit, tag, stack);
+        }
+
+        [Test]
+        public void AbsentHitsPreservePriorHitState()
+        {
+            var set = new LineSet(new[] { CylinderAt(3.0), CylinderAt(8.0) });
+            var missRay = new FastRay3d(new V3d(0.0, 0.0, 10.0), V3d.XAxis);
+            var hit = CreateSentinelHit(set, cutoff: 100.0, out var tag, out var stack);
+            var original = hit;
+
+            var found = set.ObjectsIntersectRay(
+                new[] { 0, 1 }, 0, 2, missRay,
+                objectFilter: null, hitFilter: null,
+                tmin: 0.0, tmax: 100.0, ref hit);
+
+            ClassicAssert.IsFalse(found);
+            AssertUnchanged(original, hit, tag, stack);
+        }
+    }
+}

--- a/src/Aardvark.Geometry.Intersection/LineSet.cs
+++ b/src/Aardvark.Geometry.Intersection/LineSet.cs
@@ -15,7 +15,6 @@ using Aardvark.Base;
 using Aardvark.Base.Coder;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 #pragma warning disable IDE0130 // Namespace does not match folder structure
 
@@ -26,14 +25,16 @@ namespace Aardvark.Geometry
     {
         public List<Cylinder3d> Lines = [.. cylinders];
 
-        public int ObjectCount
-        {
-            get { return Lines.Count(); }
-        }
+        public int ObjectCount => Lines.Count;
 
         public Box3d ObjectBoundingBox(int objectIndex = -1)
         {
-            return new Box3d(from line in Lines select line.BoundingBox3d);
+            if (objectIndex >= 0) return Lines[objectIndex].BoundingBox3d;
+
+            var bounds = Box3d.Invalid;
+            for (var i = 0; i < Lines.Count; i++)
+                bounds.ExtendBy(Lines[i].BoundingBox3d);
+            return bounds;
         }
 
         public bool ObjectsIntersectRay(
@@ -44,50 +45,53 @@ namespace Aardvark.Geometry
                 double tmin, double tmax,
                 ref ObjectRayHit hit)
         {
-            bool result = false;
+            var found = false;
+            var bestIndex = -1;
+            var bestHit = hit.RayHit;
+            var bestT = Fun.Min(tmax, bestHit.T);
+            var candidate = new RayHit3d(bestT);
+
             if (objectFilter == null)
             {
                 for (int i = firstIndex, e = firstIndex + indexCount; i < e; i++)
                 {
                     var index = objectIndexArray[i];
-                    if (fastRay.Ray.Hits(Lines[index], tmin, tmax, ref hit.RayHit))
+                    candidate.T = bestT;
+                    if (fastRay.Ray.Hits(Lines[index], tmin, bestT, ref candidate)
+                        && candidate.T > tmin && candidate.T < bestT
+                        && (hitFilter == null || !hitFilter(this, index, 0, candidate)))
                     {
-                       // Report.Line("hit shell of cylinder " + index + " at " + hit.RayHit.Point);
-                        if (hitFilter == null)
-                        {
-                            result = hit.Set(this, index);
-                            break;
-                        }
-
-                        if (!hitFilter(this, index, 0, hit.RayHit))
-                        {
-                            result = hit.Set(this, index);
-                            break;
-                        }
-                        else
-                        {
-                            //continue shooting
-                            //Report.Line("Filtered");
- 
-                            hit.RayHit.T = tmax;
-                        }
-                        
+                        found = true;
+                        bestIndex = index;
+                        bestHit = candidate;
+                        bestT = candidate.T;
                     }
                 }
             }
             else
             {
-                foreach (int index in objectIndexArray)
+                for (int i = firstIndex, e = firstIndex + indexCount; i < e; i++)
+                {
+                    var index = objectIndexArray[i];
                     if (objectFilter(this, index))
                     {
-                        if (fastRay.Ray.Hits(Lines[index], tmin, tmax, ref hit.RayHit)
-                            && (hitFilter == null || !hitFilter(this, index, 0, hit.RayHit)))
+                        candidate.T = bestT;
+                        if (fastRay.Ray.Hits(Lines[index], tmin, bestT, ref candidate)
+                            && candidate.T > tmin && candidate.T < bestT
+                            && (hitFilter == null || !hitFilter(this, index, 0, candidate)))
                         {
-                            result = hit.Set(this, index);
+                            found = true;
+                            bestIndex = index;
+                            bestHit = candidate;
+                            bestT = candidate.T;
                         }
                     }
+                }
             }
-            return result;
+
+            if (!found) return false;
+            hit.RayHit = bestHit;
+            return hit.Set(this, bestIndex);
         }
 
         public void ObjectHitInfo(


### PR DESCRIPTION
## Summary
- return per-cylinder bounds from indexed `ObjectBoundingBox` calls and compute aggregate bounds without LINQ allocation
- inspect exactly the requested index slice in both object-filter paths
- retain the nearest accepted cylinder regardless of index order
- apply the strict minimum of explicit `tmax` and the incoming hit cutoff
- evaluate hit filters against a reusable local candidate and commit only accepted results
- preserve the complete incoming hit after rejected or absent candidates
- retain the historical `true`-means-reject hit-filter convention and allocation-free null-object-filter path

## Regression coverage
Eight deterministic tests cover aggregate and indexed bounds, adversarial candidate order, sliced null-filter scans, sliced object filters and exclusions, rejected-near/accepted-far results, strict incoming cutoffs, and exact prior-state preservation after rejected or absent hits.

## Performance
The warmed Release null-object-filter miss path scanned fixed sets of 1, 8, 64, and 256 cylinders. Alternating before/after medians normalized per tested cylinder:

| Candidates | Before | After | Change |
| ---: | ---: | ---: | ---: |
| 1 | 48.773 ns | 49.366 ns | +1.2% |
| 8 | 45.545 ns | 44.999 ns | -1.2% |
| 64 | 44.915 ns | 45.056 ns | +0.3% |
| 256 | 45.313 ns | 44.618 ns | -1.5% |

Both implementations allocated 0 B/query. The corrected transactional scan remains statistically unchanged across candidate counts.

## Validation
- 8 focused LineSet tests passed
- 450 complete-suite tests passed with 2 existing skips
- complete Release solution build passed with warnings treated as errors

Fixes #71.