### PR TITLE
Repair clustering compression and representatives

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,5 @@
+- [Clustering] repair root compression, dense compaction, normal sums, and plane representatives (#73)
+
 ### 5.6.3
 - Updated SharpCompress to 0.48.1 to address CVE-2026-44788
 

--- a/ai/GEOMETRY.md
+++ b/ai/GEOMETRY.md
@@ -80,6 +80,14 @@ var planeClustering = new PlaneEpsilonClustering<Plane3d[]>(
 );
 ```
 
+### Dense results and representatives
+
+After clustering initialization, `IndexArray[i]` is a dense cluster ID in `[0, Count)`, and `CountArray[c]` is exactly the number of entries mapped to `c`. `ClusterConsolidate` resolves every parent to its actual root with full path compression; `CompactAndComputeCountArray` then assigns dense IDs in ascending root-index order. The array and list overloads have identical output semantics.
+
+`NormalsClustering` does not modify its input. Parallel and antiparallel members share a cluster; antiparallel vectors are sign-aligned before summation. `SumArray` uses dense cluster-ID order, so `SumArray[c]` corresponds directly to members whose `IndexArray` entry is `c`. A whole cluster's sum may be globally negated depending on its representative, but its members do not cancel merely because their input signs differ.
+
+Hash-based point and plane clustering use random bits only to choose which root remains the representative after a merge. This balances parent trees; it does not change epsilon predicates or cluster membership. Supply a deterministic `IRandomUniform` when reproducible representative IDs are required.
+
 ### Gotchas
 
 - **Call `ClusterConsolidate` before `CompactAndComputeCountArray`** – Cluster indices must point to root before compaction.

--- a/src/Aardvark.Algodat.Tests/ClusteringTests.cs
+++ b/src/Aardvark.Algodat.Tests/ClusteringTests.cs
@@ -1,0 +1,211 @@
+﻿/*
+    Copyright (C) 2006-2025. Aardvark Platform Team. http://github.com/aardvark-platform.
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+using Aardvark.Base;
+using Aardvark.Geometry.Clustering;
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+using System;
+using System.Collections.Generic;
+
+namespace Aardvark.Geometry.Tests
+{
+    [TestFixture]
+    public class ClusteringTests
+    {
+        private sealed class FixedRandom : IRandomUniform
+        {
+            private readonly int m_value;
+
+            public FixedRandom(int value)
+            {
+                m_value = value;
+            }
+
+            public int UniformIntCalls { get; private set; }
+            public int RandomBits => 31;
+            public bool GeneratesFullDoubles => false;
+            public void ReSeed(int seed) { }
+            public int UniformInt() { UniformIntCalls++; return m_value; }
+            public uint UniformUInt() => (uint)m_value;
+            public long UniformLong() => m_value;
+            public ulong UniformULong() => (uint)m_value;
+            public float UniformFloat() => 0.5f;
+            public float UniformFloatClosed() => 0.5f;
+            public float UniformFloatOpen() => 0.5f;
+            public double UniformDouble() => 0.5;
+            public double UniformDoubleClosed() => 0.5;
+            public double UniformDoubleOpen() => 0.5;
+        }
+
+        private static readonly Plane3d[] s_interleavedPlaneGroups =
+        {
+            new(V3d.XAxis, 0.0),
+            new(V3d.YAxis, 0.0),
+            new(V3d.YAxis, 0.0),
+            new(V3d.XAxis, 0.0)
+        };
+
+        [Test]
+        public void GetClusterIndexResolvesRootAndFullyCompressesDeepPath()
+        {
+            var parents = new[] { 1, 2, 3, 4, 5, 5 };
+
+            var root = parents.GetClusterIndex(0);
+
+            ClassicAssert.AreEqual(5, root);
+            CollectionAssert.AreEqual(new[] { 5, 5, 5, 5, 5, 5 }, parents);
+        }
+
+        [Test]
+        public void ArrayAndListConsolidationFullyCompressEquivalentPaths()
+        {
+            var array = new[] { 1, 2, 2, 4, 5, 5 };
+            var list = new List<int>(array);
+            var expected = new[] { 2, 2, 2, 5, 5, 5 };
+
+            array.ClusterConsolidate();
+            list.ClusterConsolidate();
+
+            CollectionAssert.AreEqual(expected, array);
+            CollectionAssert.AreEqual(expected, list);
+        }
+
+        [Test]
+        public void ArrayAndListCompactionProduceIdenticalDenseIndicesAndCounts()
+        {
+            var array = new[] { 2, 2, 2, 4, 4, 5 };
+            var list = new List<int>(array);
+
+            var arrayCounts = array.CompactAndComputeCountArray();
+            var listCounts = list.CompactAndComputeCountArray();
+
+            CollectionAssert.AreEqual(new[] { 0, 0, 0, 1, 1, 2 }, array);
+            CollectionAssert.AreEqual(array, list);
+            CollectionAssert.AreEqual(new[] { 3, 2, 1 }, arrayCounts);
+            CollectionAssert.AreEqual(arrayCounts, listCounts);
+        }
+
+        [Test]
+        public void DynamicClusteringHandlesEmptyAndSingletonPartitions()
+        {
+            var empty = new DynamicClustering();
+            empty.Init();
+            ClassicAssert.AreEqual(0, empty.Count);
+            CollectionAssert.IsEmpty(empty.IndexList);
+            CollectionAssert.IsEmpty(empty.CountArray);
+
+            var singleton = new DynamicClustering();
+            singleton.AddItem();
+            singleton.Init();
+            ClassicAssert.AreEqual(1, singleton.Count);
+            CollectionAssert.AreEqual(new[] { 0 }, singleton.IndexList);
+            CollectionAssert.AreEqual(new[] { 1 }, singleton.CountArray);
+        }
+
+        [Test]
+        public void DynamicClusteringMergeDirectionsPreserveMultiplePartitions()
+        {
+            var clustering = new DynamicClustering();
+            for (var i = 0; i < 6; i++) clustering.AddItem();
+
+            clustering.MergeLeft(0, 1);
+            clustering.MergeRight(2, 3);
+            clustering.MergeRight(0, 2);
+            clustering.MergeLeft(4, 5);
+
+            CollectionAssert.AreEqual(new[] { 3, 0, 3, 3, 4, 4 }, clustering.IndexList);
+
+            clustering.Init();
+
+            ClassicAssert.AreEqual(2, clustering.Count);
+            CollectionAssert.AreEqual(new[] { 0, 0, 0, 0, 1, 1 }, clustering.IndexList);
+            CollectionAssert.AreEqual(new[] { 4, 2 }, clustering.CountArray);
+        }
+
+        [Test]
+        public void NormalsClusteringPreservesInputAndAlignsSignedSumsWithDenseClusters()
+        {
+            var normals = new[] { V3d.XAxis, -V3d.XAxis, V3d.XAxis, V3d.YAxis, -V3d.YAxis };
+            var original = (V3d[])normals.Clone();
+
+            var clustering = new NormalsClustering(normals, delta: 1e-6);
+
+            CollectionAssert.AreEqual(original, normals);
+            ClassicAssert.AreEqual(2, clustering.Count);
+            ClassicAssert.AreEqual(clustering.Count, clustering.SumArray.Length);
+
+            var xCluster = clustering.IndexArray[0];
+            var yCluster = clustering.IndexArray[3];
+            ClassicAssert.AreNotEqual(xCluster, yCluster);
+            ClassicAssert.AreEqual(xCluster, clustering.IndexArray[1]);
+            ClassicAssert.AreEqual(xCluster, clustering.IndexArray[2]);
+            ClassicAssert.AreEqual(yCluster, clustering.IndexArray[4]);
+            ClassicAssert.AreEqual(3, clustering.CountArray[xCluster]);
+            ClassicAssert.AreEqual(2, clustering.CountArray[yCluster]);
+            ClassicAssert.IsTrue(clustering.SumArray[xCluster].ApproximateEquals(3.0 * V3d.XAxis, 1e-12));
+            ClassicAssert.IsTrue(clustering.SumArray[yCluster].ApproximateEquals(2.0 * V3d.YAxis, 1e-12));
+        }
+
+        [Test]
+        public void PlaneClusteringUsesRefreshedRandomBitsForRepresentativeDirection()
+        {
+            var low = new FixedRandom(0);
+            var high = new FixedRandom(int.MaxValue);
+
+            var lowClustering = new PlaneEpsilonClustering(
+                s_interleavedPlaneGroups.Length, s_interleavedPlaneGroups,
+                epsNormal: 0.01, epsDist: 0.01, rnd: low);
+            var highClustering = new PlaneEpsilonClustering(
+                s_interleavedPlaneGroups.Length, s_interleavedPlaneGroups,
+                epsNormal: 0.01, epsDist: 0.01, rnd: high);
+
+            AssertRandomRepresentativeResults(lowClustering, highClustering, low, high);
+        }
+
+        [Test]
+        public void GenericPlaneClusteringUsesRefreshedRandomBitsForRepresentativeDirection()
+        {
+            var low = new FixedRandom(0);
+            var high = new FixedRandom(int.MaxValue);
+
+            var lowClustering = new PlaneEpsilonClustering<Plane3d[]>(
+                s_interleavedPlaneGroups.Length, s_interleavedPlaneGroups,
+                (planes, i) => planes[i].Normal,
+                (planes, i) => planes[i].Distance,
+                epsNormal: 0.01, epsDist: 0.01, rnd: low);
+            var highClustering = new PlaneEpsilonClustering<Plane3d[]>(
+                s_interleavedPlaneGroups.Length, s_interleavedPlaneGroups,
+                (planes, i) => planes[i].Normal,
+                (planes, i) => planes[i].Distance,
+                epsNormal: 0.01, epsDist: 0.01, rnd: high);
+
+            AssertRandomRepresentativeResults(lowClustering, highClustering, low, high);
+        }
+
+        private static void AssertRandomRepresentativeResults(
+            Aardvark.Geometry.Clustering.Clustering lowClustering,
+            Aardvark.Geometry.Clustering.Clustering highClustering,
+            FixedRandom low, FixedRandom high)
+        {
+            ClassicAssert.AreEqual(2, lowClustering.Count);
+            ClassicAssert.AreEqual(2, highClustering.Count);
+            CollectionAssert.AreEqual(new[] { 2, 2 }, lowClustering.CountArray);
+            CollectionAssert.AreEqual(new[] { 2, 2 }, highClustering.CountArray);
+            CollectionAssert.AreEqual(new[] { 1, 0, 0, 1 }, lowClustering.IndexArray);
+            CollectionAssert.AreEqual(new[] { 0, 1, 1, 0 }, highClustering.IndexArray);
+            ClassicAssert.AreEqual(1, low.UniformIntCalls);
+            ClassicAssert.AreEqual(1, high.UniformIntCalls);
+        }
+    }
+}

--- a/src/Aardvark.Geometry.Clustering/Algorithms.cs
+++ b/src/Aardvark.Geometry.Clustering/Algorithms.cs
@@ -136,8 +136,16 @@ namespace Aardvark.Geometry.Clustering
         #endregion
     }
 
+    /// <summary>
+    /// Clusters parallel and antiparallel normals without modifying the supplied array.
+    /// Antiparallel members are sign-aligned before their vectors are accumulated.
+    /// </summary>
     public class NormalsClustering : Clustering
     {
+        /// <summary>
+        /// Signed normal sums in dense cluster-ID order. <c>SumArray[c]</c> aggregates exactly
+        /// the input normals whose <see cref="Clustering.IndexArray"/> entry equals <c>c</c>.
+        /// </summary>
         public readonly V3d[] SumArray;
 
         #region Constructor
@@ -145,11 +153,12 @@ namespace Aardvark.Geometry.Clustering
         public NormalsClustering(V3d[] normalArray, double delta)
         {
             var count = normalArray.Length;
+            var immutableNormals = (V3d[])normalArray.Clone();
+            var suma = (V3d[])normalArray.Clone();
             Alloc(count);
             var ca = m_indexArray;
             var sa = new int[count].Set(1);
-            var suma = SumArray;
-            var kdTree = normalArray.CreateRkdTreeDistDotProduct(0);
+            var kdTree = immutableNormals.CreateRkdTreeDistDotProduct(0);
             var query = kdTree.CreateClosestToPointQuery(delta, 0);
             for (int i = 0; i < count; i++)
             {
@@ -174,11 +183,22 @@ namespace Aardvark.Geometry.Clustering
                     V3d sum = suma[ci] + (avgDot > 0 ? suma[cj] : -suma[cj]);
                     if (si < sj) { ca[ci] = cj; ca[i] = cj; ci = cj; }
                     else { ca[cj] = ci; ca[j] = ci; }
-                    si += sj; sa[ci] = si; suma[ci] = sum;
+                    si += sj;
+                    sa[ci] = si;
+                    suma[ci] = sum;
+                    avgNormali = sum.Normalized;
                 }
                 query.Clear();
             }
-            Init();
+
+            ca.ClusterConsolidate();
+            var clusterCount = 0;
+            for (var i = 0; i < count; i++)
+                if (ca[i] == i) clusterCount++;
+            SumArray = new V3d[clusterCount];
+            for (int i = 0, ci = 0; i < count; i++)
+                if (ca[i] == i) SumArray[ci++] = suma[i];
+            InitConsolidated();
         }
 
         #endregion
@@ -354,6 +374,11 @@ namespace Aardvark.Geometry.Clustering
         #endregion
     }
 
+    /// <summary>
+    /// Clusters planes by normal and offset epsilon using a hash grid. Random bits select
+    /// which merged root remains the representative, balancing parent trees without changing
+    /// distance tests or cluster membership.
+    /// </summary>
     public class PlaneEpsilonClustering<TArray> : Clustering
     {
         #region Constructor
@@ -399,7 +424,7 @@ namespace Aardvark.Geometry.Clustering
                         var dd = Fun.Square(di - getDist(pa, j)); if (dd >= de2) continue;
                         var dn = Vec.DistanceSquared(ni, getNormal(pa, j)); if (dn >= ne2) continue;
                         var d = dn + dd; if (d < dmin) dmin = d;
-                        bit >>= 1; if (bit == 0) { rnd.UniformInt(); bit = 1 << 30; }
+                        bit >>= 1; if (bit == 0) { rndBits = rnd.UniformInt(); bit = 1 << 30; }
                         if ((rndBits & bit) != 0) { ca[ci] = cj; ca[i] = cj; ci = cj; }
                         else { ca[cj] = ci; ca[j] = ci; }
                     }
@@ -412,6 +437,11 @@ namespace Aardvark.Geometry.Clustering
         #endregion
     }
 
+    /// <summary>
+    /// Clusters planes by normal and offset epsilon using a hash grid. Random bits select
+    /// which merged root remains the representative, balancing parent trees without changing
+    /// distance tests or cluster membership.
+    /// </summary>
     public class PlaneEpsilonClustering : Clustering
     {
         #region Constructor
@@ -455,7 +485,7 @@ namespace Aardvark.Geometry.Clustering
                         var dd = Fun.Square(di - pa[j].Distance); if (dd >= de2) continue;
                         var dn = Vec.DistanceSquared(ni, pa[j].Normal); if (dn >= ne2) continue;
                         var d = dn + dd; if (d < dmin) dmin = d;
-                        bit >>= 1; if (bit == 0) { rnd.UniformInt(); bit = 1 << 30; }
+                        bit >>= 1; if (bit == 0) { rndBits = rnd.UniformInt(); bit = 1 << 30; }
                         if ((rndBits & bit) != 0) { ca[ci] = cj; ca[i] = cj; ci = cj; }
                         else { ca[cj] = ci; ca[j] = ci; }
                     }

--- a/src/Aardvark.Geometry.Clustering/Clustering.cs
+++ b/src/Aardvark.Geometry.Clustering/Clustering.cs
@@ -25,24 +25,46 @@ namespace Aardvark.Geometry.Clustering
     public static class ClusteringExtensions
     {
         /// <summary>
-        /// Obtain the cluster index of item i in the given cluster index
-        /// array. Note that hte cluster index array may be modified to
-        /// improve subsequent performance.
+        /// Obtains the root cluster index of item <paramref name="i"/> and fully compresses
+        /// every parent link on the traversed path. The operation is allocation-free.
         /// </summary>
         public static int GetClusterIndex(this int[] clusterIndexArray, int i)
         {
-            int ci = clusterIndexArray[i];
-            if (clusterIndexArray[i] != ci)
+            var root = clusterIndexArray[i];
+            if (root == i) return root;
+            while (clusterIndexArray[root] != root) root = clusterIndexArray[root];
+
+            while (clusterIndexArray[i] != i)
             {
-                do { ci = clusterIndexArray[ci]; } while (clusterIndexArray[ci] != ci);
-                clusterIndexArray[i] = ci;
+                var parent = clusterIndexArray[i];
+                clusterIndexArray[i] = root;
+                i = parent;
             }
-            return ci;
+            return root;
+        }
+
+        /// <summary>
+        /// Obtains the root cluster index of item <paramref name="i"/> and fully compresses
+        /// every parent link on the traversed path. The operation is allocation-free.
+        /// </summary>
+        public static int GetClusterIndex(this List<int> clusterIndexList, int i)
+        {
+            var root = clusterIndexList[i];
+            if (root == i) return root;
+            while (clusterIndexList[root] != root) root = clusterIndexList[root];
+
+            while (clusterIndexList[i] != i)
+            {
+                var parent = clusterIndexList[i];
+                clusterIndexList[i] = root;
+                i = parent;
+            }
+            return root;
         }
 
         /// <summary>
         /// Given two cluster indices (ci and cj) obtained with
-        /// <see cref="GetClusterIndex"/> and an item index (j) merge the two
+        /// <see cref="GetClusterIndex(int[], int)"/> and an item index (j) merge the two
         /// clusters so that the get the left cluster index (ci), and add the
         /// item to the combined cluster.
         /// </summary>
@@ -54,7 +76,7 @@ namespace Aardvark.Geometry.Clustering
 
         /// <summary>
         /// Given two cluster indices (ci and cj) obtained with
-        /// <see cref="GetClusterIndex"/> and an item index (i) merge the two
+        /// <see cref="GetClusterIndex(int[], int)"/> and an item index (i) merge the two
         /// clusters so that the get the right cluster index (cj) and add the
         /// item to the combined cluster.  In a typical double loop with the
         /// outer loop iterating over elements i with cluster ci, and the
@@ -76,28 +98,24 @@ namespace Aardvark.Geometry.Clustering
         /// <param name="clusterIndexArray"></param>
         public static void ClusterConsolidate(this int[] clusterIndexArray)
         {
-            var count = clusterIndexArray.Length;
-            var ca = clusterIndexArray;
-            for (int i = 0; i < count; i++)
-            {
-                int ci = ca[i]; if (ca[ci] != ci) { do { ci = ca[ci]; } while (ca[ci] != ci); ca[i] = ci; }
-            }
+            for (var i = 0; i < clusterIndexArray.Length; i++)
+                clusterIndexArray.GetClusterIndex(i);
         }
 
+        /// <summary>
+        /// Rewrites every list entry to directly reference its cluster root, fully compressing
+        /// intermediate parent paths without allocating temporary storage.
+        /// </summary>
         public static void ClusterConsolidate(this List<int> clusterIndexList)
         {
-            var count = clusterIndexList.Count;
-            var ca = clusterIndexList;
-            for (int i = 0; i < count; i++)
-            {
-                int ci = ca[i]; if (ca[ci] != ci) { do { ci = ca[ci]; } while (ca[ci] != ci); ca[i] = ci; }
-            }
+            for (var i = 0; i < clusterIndexList.Count; i++)
+                clusterIndexList.GetClusterIndex(i);
         }
         
         /// <summary>
-        /// Finally this call compacts the cluster indices to be contiguous
-        /// and returns a cluster count array containing the counts of each
-        /// cluster.
+        /// Compacts consolidated root indices to contiguous IDs in ascending root-index order
+        /// and returns the exact item count of each dense cluster. After the call, every item
+        /// index is in the range [0, returned array length).
         /// </summary>
         /// <param name="clusterIndexArray"></param>
         /// <returns></returns>
@@ -136,6 +154,11 @@ namespace Aardvark.Geometry.Clustering
             return clusterCountArray;
         }
 
+        /// <summary>
+        /// Compacts consolidated root indices to contiguous IDs in ascending root-index order
+        /// and returns the exact item count of each dense cluster. This is equivalent to the
+        /// array overload.
+        /// </summary>
         public static int[] CompactAndComputeCountArray(
                 this List<int> clusterIndexList)
         {
@@ -154,11 +177,11 @@ namespace Aardvark.Geometry.Clustering
             {
                 int ci = clusterIndexList[i];
                 if (ci < 0)
-                    clusterIndexList[i] = -ci - 1;
+                    clusterCountArray[-ci - 1] = i;
                 else
                 {
                     ci = clusterIndexList[ci];
-                    clusterIndexList[i] = ci < 0 ? -ci - 1 : ci;
+                    clusterIndexList[i] = -ci - 1;
                 }
             }
             for (int i = 0; i < clusterCount; i++)
@@ -231,12 +254,13 @@ namespace Aardvark.Geometry.Clustering
         public int Count { get; private set; }
 
         /// <summary>
-        /// An array containing the sizes of all clusters.
+        /// Dense cluster counts. <c>CountArray[c]</c> is the number of items whose
+        /// <see cref="IndexList"/> entry equals <c>c</c>.
         /// </summary>
         public int[] CountArray { get; private set; }
 
         /// <summary>
-        /// An array that contains index of the clsuter for each item.
+        /// A list containing the dense cluster ID for each item after <see cref="Init"/>.
         /// </summary>
         public List<int> IndexList => m_indexList;
 
@@ -248,18 +272,18 @@ namespace Aardvark.Geometry.Clustering
 
         public void MergeLeft(int i, int j)
         {
-            var ca = m_indexList;
-            int ci = ca[i]; if (ca[ci] != ci) { do { ci = ca[ci]; } while (ca[ci] != ci); ca[i] = ci; }
-            int cj = ca[j]; if (ca[cj] != cj) { do { cj = ca[cj]; } while (ca[cj] != cj); ca[j] = cj; }
-            ca[cj] = ci; ca[j] = ci;
+            var ci = m_indexList.GetClusterIndex(i);
+            var cj = m_indexList.GetClusterIndex(j);
+            m_indexList[cj] = ci;
+            m_indexList[j] = ci;
         }
 
         public void MergeRight(int i, int j)
         {
-            var ca = m_indexList;
-            int ci = ca[i]; if (ca[ci] != ci) { do { ci = ca[ci]; } while (ca[ci] != ci); ca[i] = ci; }
-            int cj = ca[j]; if (ca[cj] != cj) { do { cj = ca[cj]; } while (ca[cj] != cj); ca[j] = cj; }
-            ca[ci] = cj; ca[i] = cj;
+            var ci = m_indexList.GetClusterIndex(i);
+            var cj = m_indexList.GetClusterIndex(j);
+            m_indexList[ci] = cj;
+            m_indexList[i] = cj;
         }
 
         public void Init()
@@ -282,12 +306,13 @@ namespace Aardvark.Geometry.Clustering
         public int Count => m_count;
 
         /// <summary>
-        /// An array containing the sizes of all clusters.
+        /// Dense cluster counts. <c>CountArray[c]</c> is the number of items whose
+        /// <see cref="IndexArray"/> entry equals <c>c</c>.
         /// </summary>
         public int[] CountArray => m_countArray;
 
         /// <summary>
-        /// An array that contains index of the clsuter for each item.
+        /// An array containing the dense cluster ID for each item.
         /// </summary>
         public int[] IndexArray => m_indexArray;
 
@@ -299,24 +324,29 @@ namespace Aardvark.Geometry.Clustering
         protected void Init()
         {
             m_indexArray.ClusterConsolidate();
+            InitConsolidated();
+        }
+
+        protected void InitConsolidated()
+        {
             m_countArray = m_indexArray.CompactAndComputeCountArray();
             m_count = m_countArray.Length;
         }
 
         public void MergeLeft(int i, int j)
         {
-            var ca = m_indexArray;
-            int ci = ca[i]; if (ca[ci] != ci) { do { ci = ca[ci]; } while (ca[ci] != ci); ca[i] = ci; }
-            int cj = ca[j]; if (ca[cj] != cj) { do { cj = ca[cj]; } while (ca[cj] != cj); ca[j] = cj; }
-            ca[cj] = ci; ca[j] = ci;
+            var ci = m_indexArray.GetClusterIndex(i);
+            var cj = m_indexArray.GetClusterIndex(j);
+            m_indexArray[cj] = ci;
+            m_indexArray[j] = ci;
         }
 
         public void MergeRight(int i, int j)
         {
-            var ca = m_indexArray;
-            int ci = ca[i]; if (ca[ci] != ci) { do { ci = ca[ci]; } while (ca[ci] != ci); ca[i] = ci; }
-            int cj = ca[j]; if (ca[cj] != cj) { do { cj = ca[cj]; } while (ca[cj] != cj); ca[j] = cj; }
-            ca[ci] = cj; ca[i] = cj;
+            var ci = m_indexArray.GetClusterIndex(i);
+            var cj = m_indexArray.GetClusterIndex(j);
+            m_indexArray[ci] = cj;
+            m_indexArray[i] = cj;
         }
 
         public void ClusterMinSize(int minSize)


### PR DESCRIPTION
## Summary
- resolve actual union roots with allocation-free full path compression for arrays and lists
- use compressed root lookup in consolidation and dynamic/base merge operations
- restore list compaction root markers so array and list overloads produce identical dense IDs and counts
- keep normal inputs immutable, sign-align antiparallel members, and align `SumArray` with dense cluster IDs
- retain refreshed random words in generic and non-generic plane clustering so representative balancing is effective
- document dense result, signed-sum, and random-representative contracts

## Regression coverage
Eight focused tests cover deep parent chains and complete compression, array/list consolidation and compaction parity, empty/singleton/multiple dynamic partitions, both merge directions, normal input immutability, parallel/antiparallel/separate normal clusters, dense sum alignment, and deterministic low/high random words in both plane variants.

## Performance
Warmed Release benchmarks used fixed workloads and unchanged allocation accounting:

| Workload | Before | After | Result |
| --- | ---: | ---: | ---: |
| Flat root lookup | 0.579 ns | 0.633 ns | +0.054 ns, 0 B/op |
| Array compaction, 262,144 items | 0.590 ms | 0.602 ms | +2.0%, allocations unchanged |
| List compaction, 262,144 items | 0.817 ms | 0.832 ms | +1.8%, allocations unchanged; output corrected |
| Point clustering, 32,768 points | 2.214 ms | 2.176 ms | 1.7% faster |
| Plane clustering, 32,768 planes | 3.135 ms | 3.111 ms | 0.8% faster |
| Dense coincident planes, 32,768 | 913.859 ms | 1.837 ms | 497× faster |

Deep lookup now resolves and compresses a one-million-node path in about 3 ns/node with 0 B allocation; the previous method returned the immediate parent and therefore did not perform equivalent work. Dense-plane scaling changed from 16.5× runtime for 4× input (8,192 → 32,768) to 3.5×, while allocation remained 34 B/plane. Representative workloads retained matching corrected checksums and showed no material regression.

## Validation
- 8 focused clustering tests passed
- 450 complete-suite tests passed with 2 existing skips
- complete Release solution build passed with warnings treated as errors

Fixes #73.