### PR TITLE
Make MapParallel bounded and event driven

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,5 @@
+- [Point Clouds] make parallel mapping bounded, event-driven, and promptly cancellable (#75)
+
 ### 5.6.3
 - Updated SharpCompress to 0.48.1 to address CVE-2026-44788
 

--- a/ai/IMPORTERS.md
+++ b/ai/IMPORTERS.md
@@ -44,6 +44,12 @@ var config = ImportConfig.Default
 var pointset = PointCloud.Import(filename, config);
 ```
 
+### Parallel Chunk Transformations
+
+`MapParallel` uses the maximum parallelism supplied by its caller; non-positive values default to `Environment.ProcessorCount`. Point-cloud chunk reprojection forwards `ImportConfig.MaxDegreeOfParallelism` unchanged. The mapper keeps at most the effective parallelism number of source items, workers, and completed results live at once, so buffering and coordinator memory do not grow with the total number of chunks.
+
+Mapped chunks are emitted exactly once in worker-completion order, which may differ from input order. Worker or source-enumerator failures are rethrown directly and stop further source consumption. External cancellation, pipeline failure, and early enumerator disposal cancel the linked token supplied to every in-flight mapping function; mapping functions should observe that token to stop promptly. A completion callback, when supplied to `MapParallel` directly, runs once only after the sequence is fully and successfully consumed.
+
 ### Low-Level Chunk Access
 
 Each importer exposes a `Chunks()` method for direct chunk iteration:

--- a/src/Aardvark.Algodat.Tests/MapParallelTests.cs
+++ b/src/Aardvark.Algodat.Tests/MapParallelTests.cs
@@ -1,0 +1,583 @@
+﻿/*
+    Copyright (C) 2006-2026. Aardvark Platform Team. http://github.com/aardvark-platform.
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+using Aardvark.Base;
+using Aardvark.Data.Points;
+using Aardvark.Geometry.Points;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Aardvark.Geometry.Tests
+{
+    [TestFixture]
+    public class MapParallelTests
+    {
+        private sealed class Result
+        {
+            public Result(int value) => Value = value;
+            public int Value { get; }
+        }
+
+        private sealed class TestException : Exception
+        {
+            public TestException(string message) : base(message) { }
+        }
+
+        private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(10);
+
+        private static Task<T[]> EnumerateAsync<T>(IEnumerable<T> source)
+            => Task.Factory.StartNew(
+                () => source.ToArray(),
+                CancellationToken.None,
+                TaskCreationOptions.LongRunning | TaskCreationOptions.DenyChildAttach,
+                TaskScheduler.Default
+                );
+
+        private static void Wait(ManualResetEventSlim signal, string message)
+            => Assert.That(signal.Wait(Timeout), Is.True, message);
+
+        private static void Wait(CountdownEvent signal, string message)
+            => Assert.That(signal.Wait(Timeout), Is.True, message);
+
+        private static T Await<T>(Task<T> task)
+            => task.WaitAsync(Timeout).GetAwaiter().GetResult();
+
+        private static IEnumerable<int> CountedSource(int count, Action onRead)
+        {
+            for (var i = 0; i < count; i++)
+            {
+                onRead();
+                yield return i;
+            }
+        }
+
+        private static void UpdateMaximum(ref int maximum, int value)
+        {
+            var current = Volatile.Read(ref maximum);
+            while (value > current)
+            {
+                var previous = Interlocked.CompareExchange(ref maximum, value, current);
+                if (previous == current) return;
+                current = previous;
+            }
+        }
+
+        [Test]
+        public void EmptySourceIsLazyAndFinishesSuccessfully()
+        {
+            var sourceMoves = 0;
+            var mapCalls = 0;
+            var finishCalls = 0;
+
+            IEnumerable<int> Source()
+            {
+                Interlocked.Increment(ref sourceMoves);
+                yield break;
+            }
+
+            var mapped = Source().MapParallel(
+                (x, ct) =>
+                {
+                    Interlocked.Increment(ref mapCalls);
+                    return new Result(x);
+                },
+                maxLevelOfParallelism: 2,
+                onFinish: _ => Interlocked.Increment(ref finishCalls)
+                );
+
+            Assert.That(sourceMoves, Is.Zero);
+            Assert.That(mapCalls, Is.Zero);
+            Assert.That(finishCalls, Is.Zero);
+
+            using var enumerator = mapped.GetEnumerator();
+            Assert.That(sourceMoves, Is.Zero);
+            Assert.That(enumerator.MoveNext(), Is.False);
+            Assert.That(sourceMoves, Is.EqualTo(1));
+            Assert.That(mapCalls, Is.Zero);
+            Assert.That(finishCalls, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void SerialParallelismNeverOverlapsWorkers()
+        {
+            using var firstStarted = new ManualResetEventSlim(false);
+            using var releaseFirst = new ManualResetEventSlim(false);
+            var reads = 0;
+            var active = 0;
+            var maximum = 0;
+
+            Result Map(int value, CancellationToken ct)
+            {
+                var now = Interlocked.Increment(ref active);
+                UpdateMaximum(ref maximum, now);
+                try
+                {
+                    if (value == 0)
+                    {
+                        firstStarted.Set();
+                        releaseFirst.Wait(ct);
+                    }
+                    return new Result(value);
+                }
+                finally
+                {
+                    Interlocked.Decrement(ref active);
+                }
+            }
+
+            var task = EnumerateAsync(
+                CountedSource(4, () => Interlocked.Increment(ref reads)).MapParallel(Map, 1)
+                );
+            Wait(firstStarted, "The first worker did not start.");
+
+            Assert.That(reads, Is.EqualTo(1));
+            Assert.That(active, Is.EqualTo(1));
+            Assert.That(maximum, Is.EqualTo(1));
+
+            releaseFirst.Set();
+            var results = Await(task);
+            Assert.That(results.Select(x => x.Value), Is.EqualTo(new[] { 0, 1, 2, 3 }));
+            Assert.That(maximum, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void ConfiguredParallelismBoundsOverlap()
+        {
+            const int parallelism = 3;
+            using var started = new CountdownEvent(parallelism);
+            using var release = new ManualResetEventSlim(false);
+            var reads = 0;
+            var active = 0;
+            var maximum = 0;
+
+            Result Map(int value, CancellationToken ct)
+            {
+                var now = Interlocked.Increment(ref active);
+                UpdateMaximum(ref maximum, now);
+                if (value < parallelism) started.Signal();
+                try
+                {
+                    release.Wait(ct);
+                    return new Result(value);
+                }
+                finally
+                {
+                    Interlocked.Decrement(ref active);
+                }
+            }
+
+            var task = EnumerateAsync(
+                CountedSource(12, () => Interlocked.Increment(ref reads)).MapParallel(Map, parallelism)
+                );
+            Wait(started, "The configured workers did not overlap.");
+
+            Assert.That(reads, Is.EqualTo(parallelism));
+            Assert.That(active, Is.EqualTo(parallelism));
+            Assert.That(maximum, Is.EqualTo(parallelism));
+
+            release.Set();
+            var results = Await(task);
+            Assert.That(results.Length, Is.EqualTo(12));
+            Assert.That(maximum, Is.EqualTo(parallelism));
+        }
+
+        [Test]
+        public void ResultsAreYieldedInCompletionOrder()
+        {
+            using var started = new CountdownEvent(3);
+            var release = Enumerable.Range(0, 3).Select(_ => new ManualResetEventSlim(false)).ToArray();
+            var yielded = Enumerable.Range(0, 3).Select(_ => new ManualResetEventSlim(false)).ToArray();
+            try
+            {
+                Result Map(int value, CancellationToken ct)
+                {
+                    started.Signal();
+                    release[value].Wait(ct);
+                    return new Result(value);
+                }
+
+                var task = EnumerateAsync(
+                    Enumerable.Range(0, 3)
+                        .MapParallel(Map, 3)
+                        .Select(x =>
+                        {
+                            yielded[x.Value].Set();
+                            return x;
+                        })
+                    );
+                Wait(started, "Workers did not start.");
+
+                release[2].Set();
+                Wait(yielded[2], "The last input was not yielded first.");
+                release[0].Set();
+                Wait(yielded[0], "The first input was not yielded second.");
+                release[1].Set();
+
+                var results = Await(task);
+                Assert.That(results.Select(x => x.Value), Is.EqualTo(new[] { 2, 0, 1 }));
+            }
+            finally
+            {
+                foreach (var signal in release) signal.Set();
+                foreach (var signal in release) signal.Dispose();
+                foreach (var signal in yielded) signal.Dispose();
+            }
+        }
+
+        [Test]
+        public void EveryResultIncludingNullIsDeliveredExactlyOnce()
+        {
+            const int count = 128;
+            var calls = new int[count];
+
+            Result Map(int value, CancellationToken ct)
+            {
+                Interlocked.Increment(ref calls[value]);
+                return value % 11 == 0 ? null! : new Result(value);
+            }
+
+            var results = Enumerable.Range(0, count).MapParallel(Map, 4).ToArray();
+
+            Assert.That(results.Length, Is.EqualTo(count));
+            Assert.That(results.Count(x => x == null), Is.EqualTo(12));
+            Assert.That(calls, Is.All.EqualTo(1));
+            Assert.That(
+                results.Where(x => x != null).Select(x => x.Value).OrderBy(x => x),
+                Is.EqualTo(Enumerable.Range(0, count).Where(x => x % 11 != 0))
+                );
+        }
+
+        [TestCase(0)]
+        [TestCase(-1)]
+        public void NonPositiveParallelismUsesProcessorCount(int configuredParallelism)
+        {
+            var effectiveParallelism = Environment.ProcessorCount;
+            using var started = new CountdownEvent(effectiveParallelism);
+            using var release = new ManualResetEventSlim(false);
+            var reads = 0;
+            var active = 0;
+            var maximum = 0;
+
+            Result Map(int value, CancellationToken ct)
+            {
+                var now = Interlocked.Increment(ref active);
+                UpdateMaximum(ref maximum, now);
+                if (value < effectiveParallelism) started.Signal();
+                try
+                {
+                    release.Wait(ct);
+                    return new Result(value);
+                }
+                finally
+                {
+                    Interlocked.Decrement(ref active);
+                }
+            }
+
+            var task = EnumerateAsync(
+                CountedSource(effectiveParallelism + 1, () => Interlocked.Increment(ref reads))
+                    .MapParallel(Map, configuredParallelism)
+                );
+            Wait(started, "The default number of workers did not start.");
+
+            Assert.That(reads, Is.EqualTo(effectiveParallelism));
+            Assert.That(maximum, Is.EqualTo(effectiveParallelism));
+
+            release.Set();
+            Assert.That(Await(task).Length, Is.EqualTo(effectiveParallelism + 1));
+        }
+
+        [Test]
+        public void SourcePrefetchIsBoundedByParallelism()
+        {
+            const int parallelism = 2;
+            using var started = new CountdownEvent(parallelism);
+            using var release = new ManualResetEventSlim(false);
+            var reads = 0;
+
+            Result Map(int value, CancellationToken ct)
+            {
+                if (value < parallelism) started.Signal();
+                release.Wait(ct);
+                return new Result(value);
+            }
+
+            var task = EnumerateAsync(
+                CountedSource(1000, () => Interlocked.Increment(ref reads)).MapParallel(Map, parallelism)
+                );
+            Wait(started, "Workers did not occupy pipeline capacity.");
+            Assert.That(reads, Is.EqualTo(parallelism));
+
+            release.Set();
+            Assert.That(Await(task).Length, Is.EqualTo(1000));
+        }
+
+        [Test]
+        public void WorkerFailureIsRethrownAndStopsSourceConsumption()
+        {
+            var expected = new TestException("worker failure");
+            using var started = new CountdownEvent(2);
+            using var peerCancelled = new ManualResetEventSlim(false);
+            using var emergencyRelease = new ManualResetEventSlim(false);
+            var reads = 0;
+            var finishCalls = 0;
+
+            Result Map(int value, CancellationToken ct)
+            {
+                started.Signal();
+                Wait(started, "Workers did not start before failure.");
+                if (value == 0) throw expected;
+
+                WaitHandle.WaitAny(new[] { ct.WaitHandle, emergencyRelease.WaitHandle });
+                if (ct.IsCancellationRequested) peerCancelled.Set();
+                ct.ThrowIfCancellationRequested();
+                return new Result(value);
+            }
+
+            var task = EnumerateAsync(
+                CountedSource(100, () => Interlocked.Increment(ref reads))
+                    .MapParallel(Map, 2, _ => Interlocked.Increment(ref finishCalls))
+                );
+
+            try
+            {
+                var thrown = Assert.Throws<TestException>(() => Await(task));
+                Assert.That(thrown, Is.SameAs(expected));
+                Wait(peerCancelled, "The peer worker did not receive linked cancellation.");
+                Assert.That(reads, Is.EqualTo(2));
+                Assert.That(finishCalls, Is.Zero);
+            }
+            finally
+            {
+                emergencyRelease.Set();
+            }
+        }
+
+        [Test]
+        public void SourceEnumeratorFailureCancelsWorkersAndPreservesException()
+        {
+            var expected = new TestException("source failure");
+            using var workersStarted = new CountdownEvent(2);
+            using var workersCancelled = new CountdownEvent(2);
+            using var emergencyRelease = new ManualResetEventSlim(false);
+
+            IEnumerable<int> Source()
+            {
+                yield return 0;
+                yield return 1;
+                throw expected;
+            }
+
+            Result Map(int value, CancellationToken ct)
+            {
+                workersStarted.Signal();
+                WaitHandle.WaitAny(new[] { ct.WaitHandle, emergencyRelease.WaitHandle });
+                if (ct.IsCancellationRequested) workersCancelled.Signal();
+                ct.ThrowIfCancellationRequested();
+                return new Result(value);
+            }
+
+            var task = EnumerateAsync(Source().MapParallel(Map, 3));
+            try
+            {
+                var thrown = Assert.Throws<TestException>(() => Await(task));
+                Assert.That(thrown, Is.SameAs(expected));
+                Wait(workersStarted, "Source enumeration failed before workers started.");
+                Wait(workersCancelled, "Source failure did not cancel all workers.");
+            }
+            finally
+            {
+                emergencyRelease.Set();
+            }
+        }
+
+        [Test]
+        public void ExternalCancellationInterruptsCapacityWaitAndCancelsWorkers()
+        {
+            using var cancellation = new CancellationTokenSource();
+            using var workersStarted = new CountdownEvent(2);
+            using var workersStopped = new CountdownEvent(2);
+            using var emergencyRelease = new ManualResetEventSlim(false);
+            var reads = 0;
+
+            Result Map(int value, CancellationToken ct)
+            {
+                workersStarted.Signal();
+                try
+                {
+                    WaitHandle.WaitAny(new[] { ct.WaitHandle, emergencyRelease.WaitHandle });
+                    ct.ThrowIfCancellationRequested();
+                    return new Result(value);
+                }
+                finally
+                {
+                    workersStopped.Signal();
+                }
+            }
+
+            var task = EnumerateAsync(
+                CountedSource(100, () => Interlocked.Increment(ref reads))
+                    .MapParallel(Map, 2, ct: cancellation.Token)
+                );
+            try
+            {
+                Wait(workersStarted, "Workers did not occupy pipeline capacity.");
+                Assert.That(reads, Is.EqualTo(2));
+
+                cancellation.Cancel();
+                var thrown = Assert.Throws<OperationCanceledException>(() => Await(task));
+                Assert.That(thrown!.CancellationToken, Is.EqualTo(cancellation.Token));
+                Wait(workersStopped, "External cancellation did not stop all workers.");
+                Assert.That(reads, Is.EqualTo(2));
+            }
+            finally
+            {
+                emergencyRelease.Set();
+            }
+        }
+
+        [Test]
+        public void DisposingEnumeratorCancelsInFlightWorkers()
+        {
+            using var workersStarted = new CountdownEvent(2);
+            using var peerCancelled = new ManualResetEventSlim(false);
+            using var emergencyRelease = new ManualResetEventSlim(false);
+            var finishCalls = 0;
+
+            Result Map(int value, CancellationToken ct)
+            {
+                workersStarted.Signal();
+                Wait(workersStarted, "Workers did not start.");
+                if (value == 0) return new Result(value);
+
+                WaitHandle.WaitAny(new[] { ct.WaitHandle, emergencyRelease.WaitHandle });
+                if (ct.IsCancellationRequested) peerCancelled.Set();
+                ct.ThrowIfCancellationRequested();
+                return new Result(value);
+            }
+
+            var enumerator = Enumerable.Range(0, 10)
+                .MapParallel(Map, 2, _ => Interlocked.Increment(ref finishCalls))
+                .GetEnumerator();
+            try
+            {
+                Assert.That(enumerator.MoveNext(), Is.True);
+                Assert.That(enumerator.Current.Value, Is.EqualTo(0));
+            }
+            finally
+            {
+                enumerator.Dispose();
+            }
+
+            try
+            {
+                Wait(peerCancelled, "Enumerator disposal did not cancel the peer worker.");
+                Assert.That(finishCalls, Is.Zero);
+            }
+            finally
+            {
+                emergencyRelease.Set();
+            }
+        }
+
+        [Test]
+        public void OnFinishRunsOnceAfterSuccessfulCompletion()
+        {
+            var mapped = 0;
+            var finishCalls = 0;
+            var mappedAtFinish = -1;
+            var elapsed = TimeSpan.MinValue;
+
+            var results = Enumerable.Range(0, 32).MapParallel(
+                (value, ct) =>
+                {
+                    Interlocked.Increment(ref mapped);
+                    return new Result(value);
+                },
+                maxLevelOfParallelism: 4,
+                onFinish: duration =>
+                {
+                    elapsed = duration;
+                    mappedAtFinish = Volatile.Read(ref mapped);
+                    Interlocked.Increment(ref finishCalls);
+                }
+                ).ToArray();
+
+            Assert.That(results.Length, Is.EqualTo(32));
+            Assert.That(mapped, Is.EqualTo(32));
+            Assert.That(mappedAtFinish, Is.EqualTo(32));
+            Assert.That(finishCalls, Is.EqualTo(1));
+            Assert.That(elapsed, Is.GreaterThanOrEqualTo(TimeSpan.Zero));
+        }
+
+        [Test]
+        public void ReprojectedChunkImportRetainsEveryMappedPoint()
+        {
+            const int chunkCount = 24;
+            const int pointsPerChunk = 3;
+            const int parallelism = 4;
+            using var initialWorkers = new CountdownEvent(parallelism);
+            var reprojectCalls = 0;
+
+            var chunks = Enumerable.Range(0, chunkCount).Select(chunkIndex =>
+            {
+                var x = chunkIndex * 10.0;
+                return new Chunk(new[]
+                {
+                    new V3d(x, 0, 0),
+                    new V3d(x + 1, 1, 3),
+                    new V3d(x + 2, 3, 2),
+                });
+            }).ToArray();
+
+            IList<V3d> Reproject(IList<V3d> positions)
+            {
+                var call = Interlocked.Increment(ref reprojectCalls);
+                if (call <= parallelism)
+                {
+                    initialWorkers.Signal();
+                    Wait(initialWorkers, "Reprojection workers did not overlap.");
+                }
+                return positions.Select(p => new V3d(p.X, p.Z, p.Y)).ToArray();
+            }
+
+            var expected = chunks
+                .SelectMany(chunk => chunk.Positions)
+                .Select(p => new V3d(p.X, p.Z, p.Y))
+                .OrderBy(p => p.X).ThenBy(p => p.Y).ThenBy(p => p.Z)
+                .ToArray();
+            var config = ImportConfig.Default
+                .WithStorage(PointCloud.CreateInMemoryStore(cache: default))
+                .WithKey("map-parallel-reprojection")
+                .WithMaxDegreeOfParallelism(parallelism)
+                .WithMaxChunkPointCount(12)
+                .WithOctreeSplitLimit(8)
+                .WithMinDist(0.0)
+                .WithReproject(Reproject);
+
+            var pointSet = PointCloud.Chunks(chunks, config);
+            var actual = pointSet.QueryAllPoints()
+                .SelectMany(chunk => chunk.Positions)
+                .OrderBy(p => p.X).ThenBy(p => p.Y).ThenBy(p => p.Z)
+                .ToArray();
+
+            Assert.That(reprojectCalls, Is.EqualTo(chunkCount));
+            Assert.That(pointSet.PointCount, Is.EqualTo(chunkCount * pointsPerChunk));
+            Assert.That(actual, Is.EqualTo(expected));
+        }
+    }
+}

--- a/src/Aardvark.Data.Points.Base/EnumerableExtensions.cs
+++ b/src/Aardvark.Data.Points.Base/EnumerableExtensions.cs
@@ -19,7 +19,7 @@ using Aardvark.Base;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
+using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -133,6 +133,26 @@ namespace Aardvark.Data.Points
             return rs;
         }
 
+        /// <summary>
+        /// Maps a sequence concurrently and yields results in worker-completion order. At most
+        /// the effective parallelism number of source items, workers, and completed results are
+        /// retained at any time. Null results are yielded like any other result.
+        /// </summary>
+        /// <remarks>
+        /// A non-positive <paramref name="maxLevelOfParallelism"/> uses
+        /// <see cref="Environment.ProcessorCount"/>. Worker and source exceptions are rethrown
+        /// without an aggregate wrapper. Failure, external cancellation, or early disposal of
+        /// the returned enumerator cancels the linked token supplied to all in-flight workers;
+        /// mapping functions should observe that token for prompt shutdown. <paramref name="onFinish"/>
+        /// is invoked once only after successful complete enumeration.
+        /// </remarks>
+        /// <param name="items">The lazily consumed source sequence.</param>
+        /// <param name="map">The mapping function. Its token links external and pipeline cancellation.</param>
+        /// <param name="maxLevelOfParallelism">Maximum concurrent mappings, or a non-positive value for the processor count.</param>
+        /// <param name="onFinish">Optional callback invoked after successful complete enumeration.</param>
+        /// <param name="ct">External cancellation token.</param>
+        /// <returns>A lazy sequence of mapped results in completion order.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="map"/> is null.</exception>
         public static IEnumerable<R> MapParallel<T, R>(this IEnumerable<T> items,
             Func<T, CancellationToken, R> map,
             int maxLevelOfParallelism,
@@ -143,66 +163,180 @@ namespace Aardvark.Data.Points
             if (map == null) throw new ArgumentNullException(nameof(map));
             if (maxLevelOfParallelism < 1) maxLevelOfParallelism = Environment.ProcessorCount;
 
-            var queue = new Queue<R>();
-            var queueSemapore = new SemaphoreSlim(maxLevelOfParallelism);
+            var completions = new Queue<MapParallelCompletion<R>>(maxLevelOfParallelism);
+            var completionAvailable = new SemaphoreSlim(0, maxLevelOfParallelism);
+            var workers = new Task?[maxLevelOfParallelism];
+            var workerCount = 0;
+            var linkedCancellation = ct.CanBeCanceled
+                ? CancellationTokenSource.CreateLinkedTokenSource(ct)
+                : new CancellationTokenSource();
+            var sw = Stopwatch.StartNew();
+            var completedSuccessfully = false;
+            IEnumerator<T>? enumerator = null;
 
-            var inFlightCount = 0;
-
-            var sw = new Stopwatch(); sw.Start();
-
-            var ts = new List<Task>();
-            foreach (var item in items)
+            try
             {
-                ct.ThrowIfCancellationRequested();
+                enumerator = items.GetEnumerator();
+                var sourceCompleted = false;
 
-                queueSemapore.Wait();
-                ct.ThrowIfCancellationRequested();
-                Interlocked.Increment(ref inFlightCount);
-                ts.Add(Task.Run(() =>
+                while (true)
                 {
-                    try
-                    {
-                        var r = map(item, ct);
-                        ct.ThrowIfCancellationRequested();
-                        lock (queue) queue.Enqueue(r);
-                    }
-                    finally
-                    {
-                        Interlocked.Decrement(ref inFlightCount);
-                        queueSemapore.Release();
-                    }
-                }));
+                    ct.ThrowIfCancellationRequested();
 
-                while (queue.TryDequeue(out R? r)) { ct.ThrowIfCancellationRequested(); yield return r; }
+                    MapParallelCompletion<R>? completion = null;
+                    lock (completions)
+                    {
+                        if (completions.Count > 0)
+                        {
+                            completion = completions.Dequeue();
+                            completionAvailable.Wait(0);
+                        }
+                    }
+
+                    if (completion.HasValue)
+                    {
+                        var value = completion.Value;
+                        workers[value.Slot]!.GetAwaiter().GetResult();
+                        workers[value.Slot] = null;
+                        workerCount--;
+                        value.Error?.Throw();
+                        yield return value.Result!;
+                        continue;
+                    }
+
+                    if (!sourceCompleted && workerCount < maxLevelOfParallelism)
+                    {
+                        T item;
+                        try
+                        {
+                            if (enumerator!.MoveNext())
+                            {
+                                item = enumerator.Current;
+                            }
+                            else
+                            {
+                                sourceCompleted = true;
+                                var finishedEnumerator = enumerator;
+                                enumerator = null;
+                                finishedEnumerator.Dispose();
+                                continue;
+                            }
+                        }
+                        catch
+                        {
+                            CancelWithoutThrowing(linkedCancellation);
+                            if (enumerator != null)
+                            {
+                                try { enumerator.Dispose(); }
+                                catch { }
+                                enumerator = null;
+                            }
+                            throw;
+                        }
+
+                        var slot = 0;
+                        while (workers[slot] != null) slot++;
+
+                        var worker = Task.Run(() =>
+                        {
+                            R? result = null;
+                            ExceptionDispatchInfo? error = null;
+                            try
+                            {
+                                result = map(item, linkedCancellation.Token);
+                                linkedCancellation.Token.ThrowIfCancellationRequested();
+                            }
+                            catch (Exception e)
+                            {
+                                error = ExceptionDispatchInfo.Capture(e);
+                            }
+
+                            lock (completions)
+                            {
+                                completions.Enqueue(new MapParallelCompletion<R>(slot, result, error));
+                                completionAvailable.Release();
+                            }
+
+                            if (error != null) CancelWithoutThrowing(linkedCancellation);
+                        });
+                        workers[slot] = worker;
+                        workerCount++;
+                        continue;
+                    }
+
+                    if (workerCount > 0)
+                    {
+                        completionAvailable.Wait(ct);
+                        continue;
+                    }
+
+                    break;
+                }
+
+                sw.Stop();
+                onFinish?.Invoke(sw.Elapsed);
+                completedSuccessfully = true;
             }
-
-            while (inFlightCount > 0 || queue.Count > 0)
+            finally
             {
-                while (queue.TryDequeue(out R? r)) { ct.ThrowIfCancellationRequested(); yield return r; }
-                Task.Delay(100).Wait();
+                if (!completedSuccessfully) CancelWithoutThrowing(linkedCancellation);
+
+                try
+                {
+                    enumerator?.Dispose();
+                }
+                finally
+                {
+                    if (workerCount == 0)
+                    {
+                        completionAvailable.Dispose();
+                        linkedCancellation.Dispose();
+                    }
+                    else
+                    {
+                        var pending = new Task[workerCount];
+                        for (int i = 0, j = 0; i < workers.Length; i++)
+                            if (workers[i] != null) pending[j++] = workers[i]!;
+
+                        _ = Task.WhenAll(pending).ContinueWith(
+                            t =>
+                            {
+                                try
+                                {
+                                    if (t.IsFaulted) _ = t.Exception;
+                                    completionAvailable.Dispose();
+                                    linkedCancellation.Dispose();
+                                }
+                                catch { }
+                            },
+                            CancellationToken.None,
+                            TaskContinuationOptions.ExecuteSynchronously,
+                            TaskScheduler.Default
+                            );
+                    }
+                }
             }
-
-            Task.WaitAll([.. ts]);
-
-            sw.Stop();
-            onFinish?.Invoke(sw.Elapsed);
         }
 
-        private static bool TryDequeue<T>(this Queue<T> queue, [NotNullWhen(true)] out T? item) where T : class
+        private readonly struct MapParallelCompletion<R> where R : class
         {
-            lock (queue)
+            public MapParallelCompletion(int slot, R? result, ExceptionDispatchInfo? error)
             {
-                if (queue.Count > 0)
-                {
-                    item = queue.Dequeue();
-                    return true;
-                }
-                else
-                {
-                    item = default;
-                    return false;
-                }
+                Slot = slot;
+                Result = result;
+                Error = error;
             }
+
+            public readonly int Slot;
+            public readonly R? Result;
+            public readonly ExceptionDispatchInfo? Error;
+        }
+
+        private static void CancelWithoutThrowing(CancellationTokenSource cancellation)
+        {
+            try { cancellation.Cancel(); }
+            catch (ObjectDisposedException) { }
+            catch (AggregateException) { }
         }
     }
 }


### PR DESCRIPTION
## Summary
- replace 100 ms polling with completion signaling
- bound source prefetch, active workers, queued completions, and retained task references by effective parallelism
- preserve lazy completion-order output, null results, exactly-once delivery, non-positive defaults, and successful `onFinish` behavior
- propagate original worker/source exceptions promptly without consuming the remaining source
- cancel in-flight peers after pipeline/source failure, external cancellation, or enumerator disposal, and observe background completion
- document ordering, buffering, cancellation, and exception behavior

This leaves each caller's selected parallelism unchanged and is independent of #70.

## Regression coverage
Fourteen focused cases cover empty/lazy sources, serial and bounded overlap, deterministic out-of-order completion, null and exactly-once output, zero/negative defaults, bounded prefetch, original worker/source failures, external cancellation while capacity is full, early disposal, `onFinish`, and complete reprojection import output. Synchronization gates are used for concurrency assertions.

## Performance
Warmed Release medians used identical workloads and matching checksums:

| Workload | Before | After | Allocation |
| --- | ---: | ---: | ---: |
| 4,096 lightweight maps, parallelism 1 | 119.578 ms | 5.847 ms | 854,544 → 754,944 B |
| 32,768 lightweight maps, parallelism 20 | 223.706 ms | 29.563 ms | 6,817,936 → 6,031,200 B |
| One 10 ms map | 200.450 ms | 10.277 ms | 1,920 → 1,488 B |
| 300,000-item streaming map | 478.342 ms | 252.579 ms | 58,826,704 → 48,041,424 B |
| 65,536-point reprojection import | 694.391 ms | 387.444 ms | 115,395,576 → 115,105,152 B |

For the long stream, peak live managed memory fell from 22,850,136 B to 106,528 B. The one-item workload confirms removal of the fixed polling tail.

## Validation
- 14 focused tests passed repeatedly
- 456 complete-suite tests passed with 2 existing skips
- complete Release solution build passed with warnings treated as errors

Fixes #75.