### PR TITLE
Unify empty point-cloud import semantics

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,5 @@
+- [Point Clouds] unify empty Chunk and GenericChunk import results and progress (#77)
+
 ### 5.6.3
 - Updated SharpCompress to 0.48.1 to address CVE-2026-44788
 

--- a/ai/IMPORTERS.md
+++ b/ai/IMPORTERS.md
@@ -64,6 +64,12 @@ foreach (var chunk in Laszip.Chunks(filename, config))
 }
 ```
 
+### Empty Inputs and Progress
+
+`PointCloud.Chunks`, `PointCloud.Import`, and both `MapReduce` chunk overloads ignore empty chunks. An empty sequence, or a sequence containing only empty chunks, produces an empty `PointSet` bound to the configured storage, retaining `OctreeSplitLimit`. The result is persisted under `ImportConfig.Key`; when no key is configured, its generated effective key is available through `PointSet.Id`. Empty roots use `Guid.Empty` directly and have no backing node payload.
+
+A successful direct `MapReduce` reports terminal progress `1.0`. Top-level `Chunks` and `Import` calls report `0.0` before processing and terminate at `1.0`, including empty inputs. Calling `GenerateLod` on an empty point set returns the same object and reports completion.
+
 ### File Metadata Extraction
 
 ```csharp

--- a/src/Aardvark.Algodat.Tests/EmptyImportTests.cs
+++ b/src/Aardvark.Algodat.Tests/EmptyImportTests.cs
@@ -1,0 +1,236 @@
+﻿/*
+    Copyright (C) 2006-2026. Aardvark Platform Team. http://github.com/aardvark-platform.
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+using Aardvark.Base;
+using Aardvark.Data.Points;
+using Aardvark.Geometry.Points;
+using NUnit.Framework;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Aardvark.Geometry.Tests
+{
+    [TestFixture]
+    public class EmptyImportTests
+    {
+        public enum ImportEntryPoint
+        {
+            MapReduce,
+            Chunks,
+            Import,
+        }
+
+        private const int SplitLimit = 7;
+
+        private static ImportConfig CreateConfig(Storage storage, string key, Action<double> progress)
+            => ImportConfig.Default
+                .WithStorage(storage)
+                .WithKey(key!)
+                .WithOctreeSplitLimit(SplitLimit)
+                .WithMaxDegreeOfParallelism(2)
+                .WithMinDist(0.0)
+                .WithEnabledPartIndices(false)
+                .WithProgressCallback(progress);
+
+        private static PointSet RunChunkImport(
+            ImportEntryPoint entryPoint,
+            bool allEmpty,
+            ImportConfig config)
+        {
+            IEnumerable<Chunk> chunks = allEmpty
+                ? new[] { Chunk.Empty, new Chunk(Array.Empty<V3d>()), Chunk.Empty }
+                : Array.Empty<Chunk>();
+
+            return entryPoint switch
+            {
+                ImportEntryPoint.MapReduce => chunks.MapReduce(config),
+                ImportEntryPoint.Chunks => PointCloud.Chunks(chunks, config),
+                ImportEntryPoint.Import => PointCloud.Import(chunks, config),
+                _ => throw new ArgumentOutOfRangeException(nameof(entryPoint)),
+            };
+        }
+
+        private static PointSet RunGenericChunkImport(
+            ImportEntryPoint entryPoint,
+            bool allEmpty,
+            ImportConfig config)
+        {
+            IEnumerable<GenericChunk> chunks = allEmpty
+                ? new[] { GenericChunk.Empty, GenericChunk.Empty, GenericChunk.Empty }
+                : Array.Empty<GenericChunk>();
+
+            return entryPoint switch
+            {
+                ImportEntryPoint.MapReduce => chunks.MapReduce(config),
+                ImportEntryPoint.Chunks => PointCloud.Chunks(chunks, config),
+                ImportEntryPoint.Import => PointCloud.Import(chunks, config),
+                _ => throw new ArgumentOutOfRangeException(nameof(entryPoint)),
+            };
+        }
+
+        private static void AssertCanonicalEmpty(
+            PointSet result,
+            Storage storage,
+            string expectedKey,
+            IReadOnlyList<double> progress,
+            bool isTopLevel)
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.IsEmpty, Is.True);
+                Assert.That(result.PointCount, Is.Zero);
+                Assert.That(result.Root.Id, Is.EqualTo(Guid.Empty.ToString()));
+                Assert.That(result.Root.Value, Is.SameAs(PointSetNode.Empty));
+                Assert.That(result.Root.Value.PointCountCell, Is.Zero);
+                Assert.That(result.Root.Value.PointCountTree, Is.Zero);
+                Assert.That(result.Id, Is.EqualTo(expectedKey));
+                Assert.That(result.SplitLimit, Is.EqualTo(SplitLimit));
+                Assert.That(result.Storage, Is.SameAs(storage));
+                Assert.That(progress, Is.Not.Empty);
+                Assert.That(progress[^1], Is.EqualTo(1.0));
+                if (isTopLevel) Assert.That(progress[0], Is.EqualTo(0.0));
+            });
+
+            var reloaded = storage.GetPointSet(expectedKey);
+            Assert.That(reloaded, Is.Not.Null);
+            Assert.Multiple(() =>
+            {
+                Assert.That(reloaded!.IsEmpty, Is.True);
+                Assert.That(reloaded.PointCount, Is.Zero);
+                Assert.That(reloaded.Root.Id, Is.EqualTo(Guid.Empty.ToString()));
+                Assert.That(reloaded.Root.Value, Is.SameAs(PointSetNode.Empty));
+                Assert.That(reloaded.Root.Value.PointCountCell, Is.Zero);
+                Assert.That(reloaded.Root.Value.PointCountTree, Is.Zero);
+                Assert.That(reloaded.Id, Is.EqualTo(expectedKey));
+                Assert.That(reloaded.SplitLimit, Is.EqualTo(SplitLimit));
+                Assert.That(reloaded.Storage, Is.SameAs(storage));
+            });
+        }
+
+        [TestCase(ImportEntryPoint.MapReduce, false)]
+        [TestCase(ImportEntryPoint.MapReduce, true)]
+        [TestCase(ImportEntryPoint.Chunks, false)]
+        [TestCase(ImportEntryPoint.Chunks, true)]
+        [TestCase(ImportEntryPoint.Import, false)]
+        [TestCase(ImportEntryPoint.Import, true)]
+        public void EmptyChunkInputsHaveCanonicalResults(ImportEntryPoint entryPoint, bool allEmpty)
+        {
+            using var storage = PointCloud.CreateInMemoryStore(cache: default);
+            var progress = new List<double>();
+            var key = $"empty-chunk-{entryPoint}-{allEmpty}";
+            var config = CreateConfig(storage, key, progress.Add);
+
+            var result = RunChunkImport(entryPoint, allEmpty, config);
+
+            AssertCanonicalEmpty(result, storage, key, progress, entryPoint != ImportEntryPoint.MapReduce);
+        }
+
+        [TestCase(ImportEntryPoint.MapReduce, false)]
+        [TestCase(ImportEntryPoint.MapReduce, true)]
+        [TestCase(ImportEntryPoint.Chunks, false)]
+        [TestCase(ImportEntryPoint.Chunks, true)]
+        [TestCase(ImportEntryPoint.Import, false)]
+        [TestCase(ImportEntryPoint.Import, true)]
+        public void EmptyGenericChunkInputsHaveCanonicalResults(ImportEntryPoint entryPoint, bool allEmpty)
+        {
+            using var storage = PointCloud.CreateInMemoryStore(cache: default);
+            var progress = new List<double>();
+            var key = $"empty-generic-{entryPoint}-{allEmpty}";
+            var config = CreateConfig(storage, key, progress.Add);
+
+            var result = RunGenericChunkImport(entryPoint, allEmpty, config);
+
+            AssertCanonicalEmpty(result, storage, key, progress, entryPoint != ImportEntryPoint.MapReduce);
+        }
+
+        [TestCase(false)]
+        [TestCase(true)]
+        public void EmptyMapReducePersistsGeneratedEffectiveKey(bool generic)
+        {
+            using var storage = PointCloud.CreateInMemoryStore(cache: default);
+            var progress = new List<double>();
+            var config = CreateConfig(storage, key: null, progress.Add);
+
+            var result = generic
+                ? Array.Empty<GenericChunk>().MapReduce(config)
+                : Array.Empty<Chunk>().MapReduce(config);
+
+            Assert.That(Guid.TryParse(result.Id, out _), Is.True);
+            AssertCanonicalEmpty(result, storage, result.Id, progress, isTopLevel: false);
+        }
+
+        [Test]
+        public void EmptyGenerateLodReportsCompletionWithoutChangingResult()
+        {
+            using var storage = PointCloud.CreateInMemoryStore(cache: default);
+            var empty = new PointSet(storage, "empty-lod", Guid.Empty, SplitLimit);
+            var progress = new List<double>();
+            var config = CreateConfig(storage, "unused-lod-key", progress.Add);
+
+            var result = empty.GenerateLod(config);
+
+            Assert.That(result, Is.SameAs(empty));
+            Assert.That(progress, Is.EqualTo(new[] { 1.0 }));
+        }
+
+        [Test]
+        public void NonemptyChunkAndGenericChunkImportsRemainEquivalent()
+        {
+            var positions = new[]
+            {
+                new V3d(-2, -1, 0),
+                new V3d(-1,  2, 1),
+                new V3d( 0, -2, 2),
+                new V3d( 1,  1, 3),
+                new V3d( 2, -1, 4),
+                new V3d( 3,  2, 5),
+                new V3d( 4, -2, 6),
+                new V3d( 5,  1, 7),
+            };
+            var colors = positions.Map((_, i) => new C4b((byte)(i + 1), (byte)(i + 11), (byte)(i + 21), (byte)255));
+            var chunk = new Chunk(positions, colors, null, null, null, null, null, null);
+            var genericChunk = chunk.ToGenericChunk();
+
+            using var chunkStorage = PointCloud.CreateInMemoryStore(cache: default);
+            using var genericStorage = PointCloud.CreateInMemoryStore(cache: default);
+            var chunkProgress = new ConcurrentQueue<double>();
+            var genericProgress = new ConcurrentQueue<double>();
+            var chunkConfig = CreateConfig(chunkStorage, "nonempty-chunk", chunkProgress.Enqueue);
+            var genericConfig = CreateConfig(genericStorage, "nonempty-generic", genericProgress.Enqueue);
+
+            var fromChunk = PointCloud.Import(new[] { chunk }, chunkConfig);
+            var fromGeneric = PointCloud.Import(new[] { genericChunk }, genericConfig);
+            var chunkPositions = fromChunk.QueryAllPoints().SelectMany(x => x.Positions).OrderBy(x => x.X).ToArray();
+            var genericPositions = fromGeneric.QueryAllPoints().SelectMany(x => x.Positions).OrderBy(x => x.X).ToArray();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(fromChunk.IsEmpty, Is.False);
+                Assert.That(fromGeneric.IsEmpty, Is.False);
+                Assert.That(fromChunk.PointCount, Is.EqualTo(positions.Length));
+                Assert.That(fromGeneric.PointCount, Is.EqualTo(positions.Length));
+                Assert.That(fromChunk.SplitLimit, Is.EqualTo(SplitLimit));
+                Assert.That(fromGeneric.SplitLimit, Is.EqualTo(SplitLimit));
+                Assert.That(fromChunk.Id, Is.EqualTo("nonempty-chunk"));
+                Assert.That(fromGeneric.Id, Is.EqualTo("nonempty-generic"));
+                Assert.That(chunkPositions, Is.EqualTo(positions));
+                Assert.That(genericPositions, Is.EqualTo(positions));
+                Assert.That(chunkPositions, Is.EqualTo(genericPositions));
+                Assert.That(chunkProgress.Last(), Is.EqualTo(1.0));
+                Assert.That(genericProgress.Last(), Is.EqualTo(1.0));
+            });
+        }
+    }
+}

--- a/src/Aardvark.Geometry.PointSet/Import/ImportChunks.cs
+++ b/src/Aardvark.Geometry.PointSet/Import/ImportChunks.cs
@@ -68,7 +68,8 @@ public static partial class PointCloud
     public static PointSet Import(Chunk chunk, ImportConfig config) => Chunks(chunk, config);
 
     /// <summary>
-    /// Imports sequence of chunks.
+    /// Imports a sequence of chunks. Empty and all-empty inputs produce a persisted empty point
+    /// set under the effective key, retain the configured split limit, and complete progress.
     /// </summary>
     public static PointSet Chunks(IEnumerable<Chunk> chunks, ImportConfig config)
     {
@@ -179,23 +180,27 @@ public static partial class PointCloud
         // create LOD data
         if (config.Verbose) Report.BeginTimed("generate lod");
         final = final.GenerateLod(config.WithRandomKey().WithProgressCallback(x => config.ProgressCallback(0.66 + x * 0.34)));
-        if (final.Root.Value != null && final.Root.Value.Id != Guid.Empty && config.Storage?.GetPointCloudNode(final.Root.Value.Id) == null) throw new InvalidOperationException("Invariant 4d633e55-bf84-45d7-b9c3-c534a799242e.");
+        if (!final.IsEmpty && (final.Root.Value == null || config.Storage?.GetPointCloudNode(final.Root.Value.Id) == null)) throw new InvalidOperationException("Invariant 4d633e55-bf84-45d7-b9c3-c534a799242e.");
         if (config.Verbose) Report.End();
 
-        // create final point set with specified key (or random key when no key is specified)
-        var key = config.Key ?? Guid.NewGuid().ToString();
-        final = new PointSet(
-            storage: config.Storage ?? throw new Exception($"No storage specified. Error 5b4ebfec-d418-4ddc-9c2f-646d270cf78c."),
-            pointSetId: key,
-            rootCellId: final.Root.Value!.Id,
-            splitLimit: config.OctreeSplitLimit
-            );
-        config.Storage.Add(key, final);
-        return final;
+        return PersistFinalPointSet(final, config);
     }
 
     /// <summary>
-    /// Imports sequence of chunks.
+    /// Imports a sequence of chunks with the same persisted empty-result and progress semantics
+    /// as <see cref="Chunks(IEnumerable{Chunk}, ImportConfig)"/>.
     /// </summary>
     public static PointSet Import(IEnumerable<Chunk> chunks, ImportConfig config) => Chunks(chunks, config);
+
+    private static PointSet PersistFinalPointSet(PointSet final, ImportConfig config)
+    {
+        var storage = config.Storage ?? throw new Exception($"No storage specified. Error 5b4ebfec-d418-4ddc-9c2f-646d270cf78c.");
+        var key = config.Key ?? Guid.NewGuid().ToString();
+        var rootId = final.IsEmpty
+            ? Guid.Empty
+            : final.Root.Value?.Id ?? throw new InvalidOperationException("Expected a nonempty import root.");
+        var result = new PointSet(storage, key, rootId, config.OctreeSplitLimit);
+        storage.Add(key, result);
+        return result;
+    }
 }

--- a/src/Aardvark.Geometry.PointSet/Import/ImportGenericChunks.cs
+++ b/src/Aardvark.Geometry.PointSet/Import/ImportGenericChunks.cs
@@ -67,7 +67,8 @@ public static partial class PointCloud
         => Chunks(chunk, config);
 
     /// <summary>
-    /// Imports sequence of chunks.
+    /// Imports a sequence of chunks. Empty and all-empty inputs produce a persisted empty point
+    /// set under the effective key, retain the configured split limit, and complete progress.
     /// </summary>
     public static PointSet Chunks(IEnumerable<GenericChunk> chunks, ImportConfig config)
     {
@@ -145,19 +146,15 @@ public static partial class PointCloud
         // create LOD data
         if (config.Verbose) Report.BeginTimed("generate lod");
         final = final.GenerateLod(config.WithRandomKey().WithProgressCallback(x => config.ProgressCallback(0.66 + x * 0.34)));
-        if (config.Storage.GetPointCloudNode(final.Root.Value.Id) == null) throw new InvalidOperationException("Invariant 4d633e55-bf84-45d7-b9c3-c534a799242e.");
+        if (!final.IsEmpty && (final.Root.Value == null || config.Storage.GetPointCloudNode(final.Root.Value.Id) == null)) throw new InvalidOperationException("Invariant 4d633e55-bf84-45d7-b9c3-c534a799242e.");
         if (config.Verbose) Report.End();
 
-        // create final point set with specified key (or random key when no key is specified)
-        var key = config.Key ?? Guid.NewGuid().ToString();
-        final = new PointSet(config.Storage, key, final.Root.Value.Id, config.OctreeSplitLimit);
-        config.Storage.Add(key, final);
-
-        return final;
+        return PersistFinalPointSet(final, config);
     }
 
     /// <summary>
-    /// Imports sequence of chunks.
+    /// Imports a sequence of chunks with the same persisted empty-result and progress semantics
+    /// as <see cref="Chunks(IEnumerable{GenericChunk}, ImportConfig)"/>.
     /// </summary>
     public static PointSet Import(IEnumerable<GenericChunk> chunks, ImportConfig config) => Chunks(chunks, config);
 }

--- a/src/Aardvark.Geometry.PointSet/Import/MapReduce.cs
+++ b/src/Aardvark.Geometry.PointSet/Import/MapReduce.cs
@@ -26,6 +26,8 @@ namespace Aardvark.Geometry.Points
     {
         /// <summary>
         /// Maps a sequence of point chunks to point sets, which are then reduced to one single point set.
+        /// Empty and all-empty sequences return a persisted, storage-bound empty point set under
+        /// the effective key and report completed progress.
         /// </summary>
         public static PointSet MapReduce(this IEnumerable<Chunk> chunks, ImportConfig config)
         {
@@ -86,7 +88,7 @@ namespace Aardvark.Geometry.Points
             var totalPointSetsCount = pointsets.Count;
             if (totalPointSetsCount == 0)
             {
-                return PointSet.Empty;
+                return CreateAndPersistEmptyPointSet(config, key);
             }
 
             var doneCount = 0;
@@ -165,6 +167,14 @@ namespace Aardvark.Geometry.Points
             return final;
 
             static string formatCell(Cell c) => c.IsCenteredAtOrigin ? $"[centered, {c.Exponent}]" : c.ToString();
+        }
+
+        private static PointSet CreateAndPersistEmptyPointSet(ImportConfig config, string key)
+        {
+            var empty = new PointSet(config.Storage, key, Guid.Empty, config.OctreeSplitLimit);
+            config.Storage.Add(key, empty);
+            config.ProgressCallback(1.0);
+            return empty;
         }
     }
 }

--- a/src/Aardvark.Geometry.PointSet/Import/MapReduceGenericChunks.cs
+++ b/src/Aardvark.Geometry.PointSet/Import/MapReduceGenericChunks.cs
@@ -26,6 +26,8 @@ namespace Aardvark.Geometry.Points
     {
         /// <summary>
         /// Maps a sequence of point chunks to point sets, which are then reduced to one single point set.
+        /// Empty and all-empty sequences return a persisted, storage-bound empty point set under
+        /// the effective key and report completed progress.
         /// </summary>
         public static PointSet MapReduce(this IEnumerable<GenericChunk> chunks, ImportConfig config)
         {
@@ -79,9 +81,7 @@ namespace Aardvark.Geometry.Points
             var totalPointSetsCount = pointsets.Count;
             if (totalPointSetsCount == 0)
             {
-                var empty = new PointSet(config.Storage, key);
-                config.Storage.Add(key, empty);
-                return empty;
+                return CreateAndPersistEmptyPointSet(config, key);
             }
 
             var doneCount = 0;

--- a/src/Aardvark.Geometry.PointSet/Octrees/Lod.cs
+++ b/src/Aardvark.Geometry.PointSet/Octrees/Lod.cs
@@ -299,11 +299,16 @@ public static class LodExtensions
     }
 
     /// <summary>
-    /// Returns new octree with LOD data created.
+    /// Returns new octree with LOD data created. Empty point sets are returned unchanged and
+    /// report successful completion through the configured progress callback.
     /// </summary>
     public static PointSet GenerateLod(this PointSet self, ImportConfig config)
     {
-        if (self.Root == null || self.Root.Value.IsEmpty) return self;
+        if (self.Root == null || self.IsEmpty || self.Root.Value.IsEmpty)
+        {
+            config.ProgressCallback(1.0);
+            return self;
+        }
 
         var nodeCount = self.Root.Value.CountNodes(true);
         var loddedNodesCount = 0L;


### PR DESCRIPTION
## Summary
- make empty and all-empty `Chunk`/`GenericChunk` `MapReduce` inputs return the same storage-bound empty `PointSet`
- persist empty results under the requested or generated effective key while retaining `OctreeSplitLimit`
- skip backing-node lookup for `Guid.Empty` generic roots
- share final requested-key materialization between both top-level import pipelines
- make empty `GenerateLod` report successful completion
- document empty-input, persistence, root, and progress semantics

## Regression coverage
Sixteen focused cases cover empty enumerables and all-empty sequences through `MapReduce`, `Chunks`, and `Import` for both chunk representations, generated keys, direct empty LOD generation, storage round-tripping, root identity and counts, configured IDs and split limits, initial/terminal progress, and nonempty representation parity.

## Performance
Warmed Release medians used identical 32,768-point imports with matching checksums:

| Workload | Before | After | Allocation |
| --- | ---: | ---: | ---: |
| `Chunk` import | 538.670 ms | 538.134 ms | 59,872,776 → 59,861,512 B |
| `GenericChunk` import | 530.091 ms | 526.950 ms | 58,463,312 → 58,413,696 B |

Nonempty throughput and allocation are unchanged or slightly improved.

## Validation
- 16 focused tests passed
- 458 complete-suite tests passed with 2 existing skips
- complete Release solution build passed with warnings treated as errors

Fixes #77.