### PR TITLE
Enforce importer property selection

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,5 @@
+- [Importers] enforce EnabledProperties for optional chunk attributes (#79)
+
 ### 5.6.3
 - Updated SharpCompress to 0.48.1 to address CVE-2026-44788
 

--- a/ai/IMPORTERS.md
+++ b/ai/IMPORTERS.md
@@ -64,6 +64,14 @@ foreach (var chunk in Laszip.Chunks(filename, config))
 }
 ```
 
+### Standard Property Selection
+
+`ParseConfig.EnabledProperties` controls which optional standard arrays are emitted by custom ASCII, PTS/YXH, PLY, LAS/LAZ, and filtered E57 `Chunks` APIs. Positions are always parsed. Colors, normals, intensities, and classifications are omitted when their respective flag is disabled, avoiding their importer-side extraction and result allocation. Part-index selection is independent of these flags.
+
+Custom ASCII layouts are not modified: disabled standard-property tokens are consumed as `Skip`, while custom tokens remain unchanged. E57 `Chunks` still applies Cartesian validity filtering and fills enabled properties that are missing from individual scans when another scan provides that semantic. `E57.ChunksFull` intentionally returns all source semantics regardless of selection flags.
+
+A later `PointCloud.Import` processes chunks into an octree and generates LoD data. LoD construction may estimate normals even when source-normal parsing was disabled, so inspect low-level chunks when the distinction between imported and generated normals matters.
+
 ### File Metadata Extraction
 
 ```csharp

--- a/src/Aardvark.Algodat.Tests/ImporterEnabledPropertiesTests.cs
+++ b/src/Aardvark.Algodat.Tests/ImporterEnabledPropertiesTests.cs
@@ -1,0 +1,403 @@
+﻿/*
+    Copyright (C) 2006-2026. Aardvark Platform Team. http://github.com/aardvark-platform.
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+using Aardvark.Base;
+using Aardvark.Data.Points;
+using Aardvark.Data.Points.Import;
+using Aardvark.Geometry.Points;
+using NUnit.Framework;
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using AsciiImporter = Aardvark.Data.Points.Import.Ascii;
+using PlyImporter = Aardvark.Data.Points.Import.Ply;
+using static Aardvark.Data.Points.Import.Ascii;
+
+namespace Aardvark.Geometry.Tests
+{
+    [TestFixture]
+    public class ImporterEnabledPropertiesTests
+    {
+        private const string CustomAsciiText =
+            "1 2 3 0.1 0.2 0.3 10 20 30 40 7\n" +
+            "4 5 6 0.4 0.5 0.6 50 60 70 80 9\n";
+
+        private const string PtsText =
+            "2\n" +
+            "1 2 3 99 10 20 30\n" +
+            "4 5 6 88 40 50 60\n";
+
+        private const string YxhText =
+            "1 2 3 7 10 20 30\n" +
+            "4 5 6 9 40 50 60\n";
+
+        private const string PlyText =
+            "ply\n" +
+            "format ascii 1.0\n" +
+            "element vertex 3\n" +
+            "property double x\n" +
+            "property double y\n" +
+            "property double z\n" +
+            "property float nx\n" +
+            "property float ny\n" +
+            "property float nz\n" +
+            "property uchar red\n" +
+            "property uchar green\n" +
+            "property uchar blue\n" +
+            "property uchar alpha\n" +
+            "property ushort intensity\n" +
+            "property uchar classification\n" +
+            "end_header\n" +
+            "1 2 3 0 0 1 10 20 30 40 7 2\n" +
+            "4 5 6 1 0 0 50 60 70 80 200 4\n" +
+            "7 8 9 0 1 0 90 100 110 120 42 6\n";
+
+        private static readonly V3d[] ExpectedPositions =
+        {
+            new V3d(1, 2, 3),
+            new V3d(4, 5, 6),
+        };
+
+        private static Token[] CreateCustomLayout() => new[]
+        {
+            Token.PositionX, Token.PositionY, Token.PositionZ,
+            Token.NormalX, Token.NormalY, Token.NormalZ,
+            Token.ColorR, Token.ColorG, Token.ColorB, Token.ColorA,
+            Token.Intensity,
+        };
+
+        private static ParseConfig Selection(
+            bool colors = true,
+            bool normals = true,
+            bool intensities = true,
+            bool classifications = true,
+            bool partIndices = false)
+            => ParseConfig.Default
+                .WithMaxChunkPointCount(1024)
+                .WithReadBufferSizeInBytes(1024)
+                .WithEnabledColors(colors)
+                .WithEnabledNormals(normals)
+                .WithEnabledIntensities(intensities)
+                .WithEnabledClassifications(classifications)
+                .WithEnabledPartIndices(partIndices)
+                .WithPartIndexOffset(42);
+
+        private static MemoryStream StreamFor(string text)
+            => new(Encoding.ASCII.GetBytes(text), writable: false);
+
+        private static string WriteTempFile(string extension, string text)
+        {
+            var path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}{extension}");
+            File.WriteAllText(path, text, Encoding.ASCII);
+            return path;
+        }
+
+        private static void AssertSelection(
+            Chunk chunk,
+            bool colors,
+            bool normals,
+            bool intensities,
+            bool classifications,
+            bool partIndices)
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(chunk.HasColors, Is.EqualTo(colors));
+                Assert.That(chunk.HasNormals, Is.EqualTo(normals));
+                Assert.That(chunk.HasIntensities, Is.EqualTo(intensities));
+                Assert.That(chunk.HasClassifications, Is.EqualTo(classifications));
+                Assert.That(chunk.HasPartIndices, Is.EqualTo(partIndices));
+                if (colors) Assert.That(chunk.Colors!.Count, Is.EqualTo(chunk.Count));
+                if (normals) Assert.That(chunk.Normals!.Count, Is.EqualTo(chunk.Count));
+                if (intensities) Assert.That(chunk.Intensities!.Count, Is.EqualTo(chunk.Count));
+                if (classifications) Assert.That(chunk.Classifications!.Count, Is.EqualTo(chunk.Count));
+                if (partIndices) Assert.That(chunk.PartIndices, Is.EqualTo(42));
+            });
+        }
+
+        private static Chunk ParseCustom(Token[] layout, ParseConfig config)
+        {
+            using var stream = StreamFor(CustomAsciiText);
+            return AsciiImporter.Chunks(stream, stream.Length, layout, config).Single();
+        }
+
+        [TestCase("colors")]
+        [TestCase("normals")]
+        [TestCase("intensities")]
+        public void CustomAsciiHonorsEachStandardPropertyFlag(string disabled)
+        {
+            var layout = CreateCustomLayout();
+            var original = (Token[])layout.Clone();
+            var config = Selection(
+                colors: disabled != "colors",
+                normals: disabled != "normals",
+                intensities: disabled != "intensities");
+
+            var chunk = ParseCustom(layout, config);
+
+            AssertSelection(
+                chunk,
+                colors: disabled != "colors",
+                normals: disabled != "normals",
+                intensities: disabled != "intensities",
+                classifications: false,
+                partIndices: false);
+            Assert.That(layout, Is.EqualTo(original), "The caller's layout was modified.");
+            Assert.That(chunk.Positions, Is.EqualTo(ExpectedPositions));
+            if (chunk.HasColors) Assert.That(chunk.Colors, Is.EqualTo(new[] { new C4b(10, 20, 30, 40), new C4b(50, 60, 70, 80) }));
+            if (chunk.HasNormals) Assert.That(chunk.Normals, Is.EqualTo(new[] { new V3f(0.1f, 0.2f, 0.3f), new V3f(0.4f, 0.5f, 0.6f) }));
+            if (chunk.HasIntensities) Assert.That(chunk.Intensities, Is.EqualTo(new[] { 7, 9 }));
+        }
+
+        [TestCase(false)]
+        [TestCase(true)]
+        public void CustomAsciiAllDisabledKeepsPartIndexSelectionIndependent(bool partIndices)
+        {
+            var layout = CreateCustomLayout();
+            var original = (Token[])layout.Clone();
+            var chunk = ParseCustom(layout, Selection(false, false, false, false, partIndices));
+
+            AssertSelection(chunk, false, false, false, false, partIndices);
+            Assert.That(chunk.Positions, Is.EqualTo(ExpectedPositions));
+            Assert.That(layout, Is.EqualTo(original), "The caller's layout was modified.");
+        }
+
+        [Test]
+        public void CustomAsciiFileAndStreamSelectionsMatch()
+        {
+            var layout = CreateCustomLayout();
+            var config = Selection();
+            var path = WriteTempFile(".txt", CustomAsciiText);
+            try
+            {
+                var fromFile = AsciiImporter.Chunks(path, layout, config).Single();
+                var fromStream = ParseCustom(layout, config);
+                var disabledFromFile = AsciiImporter.Chunks(path, layout, Selection(false, false, false, false, true)).Single();
+
+                AssertSelection(fromFile, true, true, true, false, false);
+                AssertSelection(disabledFromFile, false, false, false, false, true);
+                Assert.That(disabledFromFile.Positions, Is.EqualTo(fromFile.Positions));
+                Assert.That(fromFile.Positions, Is.EqualTo(fromStream.Positions));
+                Assert.That(fromFile.Colors, Is.EqualTo(fromStream.Colors));
+                Assert.That(fromFile.Normals, Is.EqualTo(fromStream.Normals));
+                Assert.That(fromFile.Intensities, Is.EqualTo(fromStream.Intensities));
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        [TestCase("pts", true, true, false)]
+        [TestCase("pts", false, true, true)]
+        [TestCase("yxh", true, true, false)]
+        [TestCase("yxh", false, true, true)]
+        [TestCase("yxh", true, false, true)]
+        [TestCase("yxh", false, false, true)]
+        public void BuiltInAsciiImportersHonorSelection(string format, bool colors, bool intensities, bool partIndices)
+        {
+            var text = format == "pts" ? PtsText : YxhText;
+            using var stream = StreamFor(text);
+            var config = Selection(colors, normals: false, intensities, classifications: false, partIndices);
+            var chunk = format == "pts"
+                ? Pts.Chunks(stream, stream.Length, config).Single()
+                : Yxh.Chunks(stream, stream.Length, config).Single();
+            var hasIntensities = format == "yxh" && intensities;
+
+            AssertSelection(chunk, colors, false, hasIntensities, false, partIndices);
+            Assert.That(chunk.Positions, Is.EqualTo(ExpectedPositions));
+            if (colors) Assert.That(chunk.Colors, Is.EqualTo(new[] { new C4b(10, 20, 30, 255), new C4b(40, 50, 60, 255) }));
+            if (hasIntensities) Assert.That(chunk.Intensities, Is.EqualTo(new[] { 7, 9 }));
+        }
+
+        private static Chunk ParsePly(ParseConfig config)
+        {
+            using var stream = StreamFor(PlyText);
+            return PlyImporter.Chunks(stream, stream.Length, config).Single();
+        }
+
+        [TestCase("none", true, true, true, true)]
+        [TestCase("colors", false, true, true, true)]
+        [TestCase("normals", true, false, true, true)]
+        [TestCase("intensities", true, true, false, true)]
+        [TestCase("classifications", true, true, true, false)]
+        [TestCase("all", false, false, false, false)]
+        public void PlyHonorsEveryStandardPropertyFlag(
+            string _, bool colors, bool normals, bool intensities, bool classifications)
+        {
+            var partIndices = !colors && !normals && !intensities && !classifications;
+            var chunk = ParsePly(Selection(colors, normals, intensities, classifications, partIndices));
+
+            AssertSelection(chunk, colors, normals, intensities, classifications, partIndices);
+            Assert.That(chunk.Positions, Is.EqualTo(new[] { new V3d(1, 2, 3), new V3d(4, 5, 6), new V3d(7, 8, 9) }));
+            if (colors) Assert.That(chunk.Colors, Is.EqualTo(new[] { new C4b(10, 20, 30, 40), new C4b(50, 60, 70, 80), new C4b(90, 100, 110, 120) }));
+            if (normals) Assert.That(chunk.Normals, Is.EqualTo(new[] { V3f.OOI, V3f.IOO, V3f.OIO }));
+            if (intensities) Assert.That(chunk.Intensities, Is.EqualTo(new[] { 7, 200, 42 }));
+            if (classifications) Assert.That(chunk.Classifications, Is.EqualTo(new byte[] { 2, 4, 6 }));
+        }
+
+        [Test]
+        public void PlyFileAndStreamSelectionsMatch()
+        {
+            var path = WriteTempFile(".ply", PlyText);
+            try
+            {
+                var config = Selection();
+                var fromFile = PlyImporter.Chunks(path, config).Single();
+                var fromStream = ParsePly(config);
+                var disabledFromFile = PlyImporter.Chunks(path, Selection(false, false, false, false, true)).Single();
+
+                AssertSelection(disabledFromFile, false, false, false, false, true);
+                Assert.That(disabledFromFile.Positions, Is.EqualTo(fromFile.Positions));
+                Assert.That(fromFile.Positions, Is.EqualTo(fromStream.Positions));
+                Assert.That(fromFile.Colors, Is.EqualTo(fromStream.Colors));
+                Assert.That(fromFile.Normals, Is.EqualTo(fromStream.Normals));
+                Assert.That(fromFile.Intensities, Is.EqualTo(fromStream.Intensities));
+                Assert.That(fromFile.Classifications, Is.EqualTo(fromStream.Classifications));
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        [TestCase("las")]
+        [TestCase("laz")]
+        public void LaszipFileAndStreamSelectionPreservesPublicParserBehavior(string extension)
+        {
+            var path = Path.Combine(Config.TestDataDir, $"test.{extension}");
+            var raw = LASZip.Parser.ReadPoints(path, 1024, verbose: false).Single();
+            var all = Laszip.Chunks(path, Selection()).Single();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(raw.Positions.Length, Is.EqualTo(3));
+                Assert.That(raw.Colors, Is.Not.Null);
+                Assert.That(raw.Intensities, Is.Not.Null);
+                Assert.That(raw.Classifications, Is.Not.Null);
+                Assert.That(raw.ReturnNumbers, Is.Not.Null);
+                Assert.That(raw.NumberOfReturnsOfPulses, Is.Not.Null);
+            });
+            AssertSelection(all, true, false, true, true, false);
+            Assert.That(all.Colors, Is.EqualTo(new[] { new C4b(152, 153, 154, 255), new C4b(255, 0, 128, 255), new C4b(17, 42, 201, 255) }));
+            Assert.That(all.Intensities, Is.EqualTo(new[] { 0, 0, 0 }));
+            Assert.That(all.Classifications, Is.EqualTo(new byte[] { 0, 0, 0 }));
+
+            foreach (var disabled in new[] { "colors", "intensities", "classifications" })
+            {
+                var chunk = Laszip.Chunks(path, Selection(
+                    colors: disabled != "colors",
+                    normals: false,
+                    intensities: disabled != "intensities",
+                    classifications: disabled != "classifications")).Single();
+                AssertSelection(
+                    chunk,
+                    disabled != "colors",
+                    false,
+                    disabled != "intensities",
+                    disabled != "classifications",
+                    false);
+            }
+
+            using var stream = File.OpenRead(path);
+            var selected = Laszip.Chunks(stream, stream.Length, Selection(false, false, false, false, true)).Single();
+            AssertSelection(selected, false, false, false, false, true);
+            Assert.That(selected.Positions, Is.EqualTo(all.Positions));
+        }
+
+        [Test]
+        public void E57SelectionDoesNotAffectChunksFullOrPartIndices()
+        {
+            var path = Path.Combine(Config.TestDataDir, "test.e57");
+            var all = E57.Chunks(path, Selection()).Single();
+            AssertSelection(all, true, false, true, true, false);
+            Assert.That(all.Colors, Is.EqualTo(new[] { new C4b(152, 153, 154, 255), new C4b(255, 0, 128, 255), new C4b(17, 42, 201, 255) }));
+            Assert.That(all.Intensities, Is.EqualTo(new[] { 5300, 65535, 0 }));
+            Assert.That(all.Classifications, Is.EqualTo(new byte[] { 0, 0, 0 }));
+
+            var noColors = E57.Chunks(path, Selection(colors: false)).Single();
+            AssertSelection(noColors, false, false, true, true, false);
+            var noIntensities = E57.Chunks(path, Selection(intensities: false)).Single();
+            AssertSelection(noIntensities, true, false, false, true, false);
+            var noNormals = E57.Chunks(path, Selection(normals: false)).Single();
+            AssertSelection(noNormals, true, false, true, true, false);
+            var noClassifications = E57.Chunks(path, Selection(classifications: false)).Single();
+            AssertSelection(noClassifications, true, false, true, false, false);
+
+            var disabled = Selection(false, false, false, false, true);
+            using (var stream = File.OpenRead(path))
+            {
+                var selected = E57.Chunks(stream, stream.Length, disabled).Single();
+                AssertSelection(selected, false, false, false, false, true);
+                Assert.That(selected.Positions, Is.EqualTo(all.Positions));
+            }
+
+            var full = E57.ChunksFull(path, disabled).Single();
+            Assert.That(full.Colors, Is.Not.Null);
+            Assert.That(full.Intensities, Is.Not.Null);
+            Assert.That(full.Colors.Length, Is.EqualTo(full.Count));
+            Assert.That(full.Intensities.Length, Is.EqualTo(full.Count));
+        }
+
+        [TestCase("pts")]
+        [TestCase("ply")]
+        [TestCase("las")]
+        [TestCase("laz")]
+        [TestCase("e57")]
+        public void HighLevelImportsSuppressDisabledSourceAttributesButGenerateLodNormals(string format)
+        {
+            string path;
+            var delete = false;
+            switch (format)
+            {
+                case "pts": path = WriteTempFile(".pts", "3\n" + PtsText.Substring(2) + "7 8 9 77 70 80 90\n"); delete = true; break;
+                case "ply": path = WriteTempFile(".ply", PlyText); delete = true; break;
+                default: path = Path.Combine(Config.TestDataDir, $"test.{format}"); break;
+            }
+
+            try
+            {
+                using var storage = PointCloud.CreateInMemoryStore(cache: default);
+                var enabled = new EnabledProperties()
+                    .WithColors(false)
+                    .WithNormals(false)
+                    .WithIntensities(false)
+                    .WithClassifications(false)
+                    .WithPartIndices(false);
+                var config = ImportConfig.Default
+                    .WithStorage(storage)
+                    .WithKey($"selection-{format}")
+                    .WithOctreeSplitLimit(16)
+                    .WithMaxChunkPointCount(1024)
+                    .WithEnabledProperties(enabled);
+
+                var pointSet = PointCloud.Import(path, config);
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(pointSet.PointCount, Is.EqualTo(3));
+                    Assert.That(pointSet.HasColors, Is.False);
+                    Assert.That(pointSet.HasIntensities, Is.False);
+                    Assert.That(pointSet.HasClassifications, Is.False);
+                    Assert.That(pointSet.HasPartIndices, Is.False);
+                    Assert.That(pointSet.HasNormals, Is.True, "LoD generation should still synthesize normals.");
+                });
+            }
+            finally
+            {
+                if (delete) File.Delete(path);
+            }
+        }
+    }
+}

--- a/src/Aardvark.Data.E57/ImportE57.cs
+++ b/src/Aardvark.Data.E57/ImportE57.cs
@@ -38,6 +38,22 @@ namespace Aardvark.Data.Points.Import
         /// </summary>
         public static readonly PointCloudFileFormat E57Format;
 
+        private static readonly ImmutableHashSet<PointPropertySemantics> s_excludedSemantics =
+            ImmutableHashSet<PointPropertySemantics>.Empty
+                //.Add(PointPropertySemantics.CartesianInvalidState)
+                .Add(PointPropertySemantics.ColumnIndex)
+                .Add(PointPropertySemantics.IsColorInvalid)
+                .Add(PointPropertySemantics.IsIntensityInvalid)
+                .Add(PointPropertySemantics.IsTimeStampInvalid)
+                .Add(PointPropertySemantics.ReturnCount)
+                .Add(PointPropertySemantics.ReturnIndex)
+                .Add(PointPropertySemantics.RowIndex)
+                .Add(PointPropertySemantics.SphericalInvalidState)
+                .Add(PointPropertySemantics.TimeStamp);
+
+        private static readonly ImmutableHashSet<PointPropertySemantics>[] s_excludedSemanticsBySelection =
+            new ImmutableHashSet<PointPropertySemantics>[16];
+
         static E57()
         {
             E57Format = new PointCloudFileFormat("e57", [".e57"], E57Info, Chunks);
@@ -45,7 +61,7 @@ namespace Aardvark.Data.Points.Import
         }
         
         /// <summary>
-        /// Parses .e57 file.
+        /// Parses an E57 file, excluding optional standard semantics disabled by the configuration.
         /// </summary>
         public static IEnumerable<Chunk> Chunks(string filename, ParseConfig config)
         {
@@ -160,28 +176,18 @@ namespace Aardvark.Data.Points.Import
         }
 
         /// <summary>
-        /// Parses .e57 stream.
+        /// Parses an E57 stream, excluding optional standard semantics disabled by the configuration.
         /// </summary>
         public static IEnumerable<Chunk> Chunks(this Stream stream, long streamLengthInBytes, ParseConfig config)
             => Chunks(stream, streamLengthInBytes, config, verifyChecksums: false);
 
         /// <summary>
-        /// Parses .e57 stream.
+        /// Parses an E57 stream, optionally verifies checksums, and excludes optional standard
+        /// semantics disabled by the configuration. Cartesian validity data remains available for filtering.
         /// </summary>
         public static IEnumerable<Chunk> Chunks(this Stream stream, long streamLengthInBytes, ParseConfig config, bool verifyChecksums)
         {
-            var exclude = ImmutableHashSet<PointPropertySemantics>.Empty
-                //.Add(PointPropertySemantics.CartesianInvalidState)
-                .Add(PointPropertySemantics.ColumnIndex)
-                .Add(PointPropertySemantics.IsColorInvalid)
-                .Add(PointPropertySemantics.IsIntensityInvalid)
-                .Add(PointPropertySemantics.IsTimeStampInvalid)
-                .Add(PointPropertySemantics.ReturnCount)
-                .Add(PointPropertySemantics.ReturnIndex)
-                .Add(PointPropertySemantics.RowIndex)
-                .Add(PointPropertySemantics.SphericalInvalidState)
-                .Add(PointPropertySemantics.TimeStamp)
-                ;
+            var exclude = GetExcludedSemantics(config.EnabledProperties);
 
             checked
             {
@@ -227,27 +233,32 @@ namespace Aardvark.Data.Points.Import
                         var e57chunk = new E57Chunk(Properties, data3d, Positions);
 
                         // ensure that there are colors (if e57 chunk has no colors then add colors)
-                        var cs = e57chunk.Colors?.Map(c => new C4b(c)) ?? Positions.Map(_ => config.EnabledProperties.DefaultColor);
+                        var cs = config.EnabledProperties.Colors
+                            ? e57chunk.Colors?.Map(c => new C4b(c)) ?? Positions.Map(_ => config.EnabledProperties.DefaultColor)
+                            : null;
 
-                        // ensure that there are normals, if any e57 chunk has normals (according to 'semanticsAll') 
-                        var ns = e57chunk.Normals;
-                        if (ns == null && semanticsAll.Contains(PointPropertySemantics.NormalX))
+                        // ensure that there are normals, if any e57 chunk has normals (according to 'semanticsAll')
+                        var ns = config.EnabledProperties.Normals ? e57chunk.Normals : null;
+                        if (config.EnabledProperties.Normals && ns == null && semanticsAll.Contains(PointPropertySemantics.NormalX))
                         {
                             ns = new V3f[Positions.Length];
                             for (var i = 0; i < ns.Length; i++) ns[i] = config.EnabledProperties.DefaultNormal;
                         }
 
-                        // ensure that there are intensities, if any e57 chunk has intensities (according to 'semanticsAll') 
-                        var js = e57chunk.Intensities;
-                        if (js == null && semanticsAll.Contains(PointPropertySemantics.Intensity))
+                        // ensure that there are intensities, if any e57 chunk has intensities (according to 'semanticsAll')
+                        var js = config.EnabledProperties.Intensities ? e57chunk.Intensities : null;
+                        if (config.EnabledProperties.Intensities && js == null && semanticsAll.Contains(PointPropertySemantics.Intensity))
                         {
                             js = new int[Positions.Length];
                             for (var i = 0; i < js.Length; i++) js[i] = config.EnabledProperties.DefaultIntensity;
                         }
 
-                        // ensure that there are classifications, if any e57 chunk has classifications (according to 'semanticsAll') 
-                        var ks = e57chunk.Classification?.Map(x => (byte)x);
-                        if (ks == null && semanticsAll.Contains(PointPropertySemantics.Intensity))
+                        // ensure that there are classifications, if any e57 chunk has classifications (according to 'semanticsAll')
+                        var ks = config.EnabledProperties.Classifications ? e57chunk.Classification?.Map(x => (byte)x) : null;
+                        // Intensity preserves the historical all-enabled default; Classification covers mixed scans.
+                        if (config.EnabledProperties.Classifications && ks == null &&
+                            (semanticsAll.Contains(PointPropertySemantics.Classification) ||
+                             semanticsAll.Contains(PointPropertySemantics.Intensity)))
                         {
                             ks = new byte[Positions.Length];
                             for (var i = 0; i < ks.Length; i++) ks[i] = config.EnabledProperties.DefaultClassification;
@@ -291,6 +302,37 @@ namespace Aardvark.Data.Points.Import
 
                 if (config.Verbose) Report.Line();
             }
+        }
+
+        private static ImmutableHashSet<PointPropertySemantics> GetExcludedSemantics(EnabledProperties enabled)
+        {
+            var mask =
+                (enabled.Colors ? 0 : 1) |
+                (enabled.Normals ? 0 : 2) |
+                (enabled.Intensities ? 0 : 4) |
+                (enabled.Classifications ? 0 : 8);
+            if (mask == 0) return s_excludedSemantics;
+
+            var cached = Volatile.Read(ref s_excludedSemanticsBySelection[mask]);
+            if (cached != null) return cached;
+
+            var result = s_excludedSemantics;
+            if ((mask & 1) != 0)
+                result = result
+                    .Add(PointPropertySemantics.ColorRed)
+                    .Add(PointPropertySemantics.ColorGreen)
+                    .Add(PointPropertySemantics.ColorBlue);
+            if ((mask & 2) != 0)
+                result = result
+                    .Add(PointPropertySemantics.NormalX)
+                    .Add(PointPropertySemantics.NormalY)
+                    .Add(PointPropertySemantics.NormalZ);
+            if ((mask & 4) != 0)
+                result = result.Add(PointPropertySemantics.Intensity);
+            if ((mask & 8) != 0)
+                result = result.Add(PointPropertySemantics.Classification);
+
+            return Interlocked.CompareExchange(ref s_excludedSemanticsBySelection[mask], result, null) ?? result;
         }
 
         /// <summary>

--- a/src/Aardvark.Data.Points.Ascii/ImportAscii.cs
+++ b/src/Aardvark.Data.Points.Ascii/ImportAscii.cs
@@ -171,6 +171,35 @@ namespace Aardvark.Data.Points.Import
                layout.Contains(Token.CustomFloat64)
                ;
 
+        private static bool IsColorToken(Token token)
+            => token == Token.ColorR || token == Token.ColorRf ||
+               token == Token.ColorG || token == Token.ColorGf ||
+               token == Token.ColorB || token == Token.ColorBf ||
+               token == Token.ColorA || token == Token.ColorAf;
+
+        private static bool IsNormalToken(Token token)
+            => token == Token.NormalX || token == Token.NormalY || token == Token.NormalZ;
+
+        internal static Token[] ApplyEnabledProperties(Token[] layout, EnabledProperties enabled)
+        {
+            if (enabled.Colors && enabled.Normals && enabled.Intensities) return layout;
+
+            Token[]? result = null;
+            for (var i = 0; i < layout.Length; i++)
+            {
+                var token = layout[i];
+                var disabled =
+                    (!enabled.Colors && IsColorToken(token)) ||
+                    (!enabled.Normals && IsNormalToken(token)) ||
+                    (!enabled.Intensities && token == Token.Intensity);
+                if (!disabled) continue;
+
+                result ??= (Token[])layout.Clone();
+                result[i] = Token.Skip;
+            }
+            return result ?? layout;
+        }
+
         /// <summary>
         /// </summary>
         public static PointCloudFileFormat CreateFormat(string description, Token[] lineDefinition)
@@ -180,22 +209,26 @@ namespace Aardvark.Data.Points.Import
                 );
 
         /// <summary>
-        /// Parses ASCII file.
+        /// Parses an ASCII file, consuming disabled standard-property tokens as skips without
+        /// modifying the supplied line definition.
         /// </summary>
         public static IEnumerable<Chunk> Chunks(string filename, Token[] lineDefinition, ParseConfig config)
         {
+            var effectiveLineDefinition = ApplyEnabledProperties(lineDefinition, config.EnabledProperties);
             Chunk lineParser(byte[] buffer, int count, double filterDist, int? partIndices)
-                => LineParsers.Custom(buffer, count, filterDist, lineDefinition, partIndices);
+                => LineParsers.Custom(buffer, count, filterDist, effectiveLineDefinition, partIndices);
             return Parsing.AsciiLines(lineParser, filename, config);
         }
 
         /// <summary>
-        /// Parses ASCII stream.
+        /// Parses an ASCII stream, consuming disabled standard-property tokens as skips without
+        /// modifying the supplied line definition.
         /// </summary>
         public static IEnumerable<Chunk> Chunks(this Stream stream, long streamLengthInBytes, Token[] lineDefinition, ParseConfig config)
         {
+            var effectiveLineDefinition = ApplyEnabledProperties(lineDefinition, config.EnabledProperties);
             Chunk lineParser(byte[] buffer, int count, double filterDist, int? partIndices)
-                => LineParsers.Custom(buffer, count, filterDist, lineDefinition, partIndices);
+                => LineParsers.Custom(buffer, count, filterDist, effectiveLineDefinition, partIndices);
             return Parsing.AsciiLines(lineParser, stream, streamLengthInBytes, config);
         }
 

--- a/src/Aardvark.Data.Points.Ascii/ImportPts.cs
+++ b/src/Aardvark.Data.Points.Ascii/ImportPts.cs
@@ -28,6 +28,13 @@ namespace Aardvark.Data.Points.Import
         /// </summary>
         public static readonly PointCloudFileFormat PtsFormat;
 
+        private static readonly Ascii.Token[] s_lineDefinition =
+        [
+            Ascii.Token.PositionX, Ascii.Token.PositionY, Ascii.Token.PositionZ,
+            Ascii.Token.Skip,
+            Ascii.Token.ColorR, Ascii.Token.ColorG, Ascii.Token.ColorB,
+        ];
+
         static Pts()
         {
             PtsFormat = new PointCloudFileFormat("pts", [".pts"], PtsInfo, Chunks);
@@ -35,16 +42,16 @@ namespace Aardvark.Data.Points.Import
         }
 
         /// <summary>
-        /// Parses .pts file.
+        /// Parses a PTS file while omitting disabled color output.
         /// </summary>
         public static IEnumerable<Chunk> Chunks(string filename, ParseConfig config)
-            => Parsing.AsciiLines(LineParsers.XYZSRGB, filename, config);
+            => Ascii.Chunks(filename, s_lineDefinition, config);
 
         /// <summary>
-        /// Parses .pts stream.
+        /// Parses a PTS stream while omitting disabled color output.
         /// </summary>
         public static IEnumerable<Chunk> Chunks(this Stream stream, long streamLengthInBytes, ParseConfig config)
-            => Parsing.AsciiLines(LineParsers.XYZSRGB, stream, streamLengthInBytes, config);
+            => Ascii.Chunks(stream, streamLengthInBytes, s_lineDefinition, config);
 
         /// <summary>
         /// Gets general info for .pts file.

--- a/src/Aardvark.Data.Points.Ascii/ImportYxh.cs
+++ b/src/Aardvark.Data.Points.Ascii/ImportYxh.cs
@@ -28,6 +28,13 @@ namespace Aardvark.Data.Points.Import
         /// </summary>
         public static readonly PointCloudFileFormat YxhFormat;
 
+        private static readonly Ascii.Token[] s_lineDefinition =
+        [
+            Ascii.Token.PositionX, Ascii.Token.PositionY, Ascii.Token.PositionZ,
+            Ascii.Token.Intensity,
+            Ascii.Token.ColorR, Ascii.Token.ColorG, Ascii.Token.ColorB,
+        ];
+
         static Yxh()
         {
             YxhFormat = new PointCloudFileFormat("yxh", [".yxh"], YxhInfo, Chunks);
@@ -35,16 +42,16 @@ namespace Aardvark.Data.Points.Import
         }
 
         /// <summary>
-        /// Parses .yxh file.
+        /// Parses a YXH file while omitting disabled color and intensity output.
         /// </summary>
         public static IEnumerable<Chunk> Chunks(string filename, ParseConfig config)
-            => Parsing.AsciiLines(LineParsers.XYZIRGB, filename, config);
+            => Ascii.Chunks(filename, s_lineDefinition, config);
 
         /// <summary>
-        /// Parses .yxh stream.
+        /// Parses a YXH stream while omitting disabled color and intensity output.
         /// </summary>
         public static IEnumerable<Chunk> Chunks(this Stream stream, long streamLengthInBytes, ParseConfig config)
-            => Parsing.AsciiLines(LineParsers.XYZIRGB, stream, streamLengthInBytes, config);
+            => Ascii.Chunks(stream, streamLengthInBytes, s_lineDefinition, config);
 
         /// <summary>
         /// Gets general info for .pts file.

--- a/src/Aardvark.Data.Points.Base/ParseConfig.cs
+++ b/src/Aardvark.Data.Points.Base/ParseConfig.cs
@@ -21,7 +21,9 @@ using System.Threading;
 namespace Aardvark.Data.Points
 {
     /// <summary>
-    /// Specifies properties to parse and import.
+    /// Specifies optional standard properties to parse and import. Importer chunk APIs always
+    /// retain positions and independently omit disabled color, normal, intensity,
+    /// classification, and part-index arrays.
     /// </summary>
     public class EnabledProperties
     {

--- a/src/Aardvark.Data.Points.LasZip/Import.cs
+++ b/src/Aardvark.Data.Points.LasZip/Import.cs
@@ -53,16 +53,26 @@ namespace Aardvark.Data.Points.Import
         }
 
         /// <summary>
-        /// Parses LASzip (.las, .laz) file.
+        /// Parses a LAS/LAZ file without allocating optional standard arrays disabled by the configuration.
         /// </summary>
         public static IEnumerable<Chunk> Chunks(string filename, ParseConfig config)
-            => Chunks(LASZip.Parser.ReadPoints(filename, config.MaxChunkPointCount, config.Verbose), partIndices: config.EnabledProperties.PartIndices ? config.PartIndexOffset : null);
+            => Chunks(LASZip.Parser.ReadPoints(
+                filename, config.MaxChunkPointCount, config.Verbose,
+                config.EnabledProperties.Colors,
+                config.EnabledProperties.Intensities,
+                config.EnabledProperties.Classifications),
+                partIndices: config.EnabledProperties.PartIndices ? config.PartIndexOffset : null);
 
         /// <summary>
-        /// Parses LASzip (.las, .laz) stream.
+        /// Parses a LAS/LAZ stream without allocating optional standard arrays disabled by the configuration.
         /// </summary>
         public static IEnumerable<Chunk> Chunks(this Stream stream, long streamLengthInBytes, ParseConfig config)
-            => Chunks(LASZip.Parser.ReadPoints(stream, config.MaxChunkPointCount, config.Verbose), partIndices: config.EnabledProperties.PartIndices ? config.PartIndexOffset : null);
+            => Chunks(LASZip.Parser.ReadPoints(
+                stream, config.MaxChunkPointCount, config.Verbose,
+                config.EnabledProperties.Colors,
+                config.EnabledProperties.Intensities,
+                config.EnabledProperties.Classifications),
+                partIndices: config.EnabledProperties.PartIndices ? config.PartIndexOffset : null);
 
         private static IEnumerable<Chunk> Chunks(this IEnumerable<LASZip.Points> xs, object? partIndices)
             => xs.Select(x => new Chunk(

--- a/src/Aardvark.Data.Points.LasZip/Parser.cs
+++ b/src/Aardvark.Data.Points.LasZip/Parser.cs
@@ -132,10 +132,14 @@ namespace LASZip
         /// Reads point data from file and returns chunks of given size.
         /// </summary>
         public static IEnumerable<Points> ReadPoints(string filename, int numberOfPointsPerChunk, bool verbose)
+            => ReadPoints(filename, numberOfPointsPerChunk, verbose, colors: true, intensities: true, classifications: true);
+
+        internal static IEnumerable<Points> ReadPoints(string filename, int numberOfPointsPerChunk, bool verbose,
+            bool colors, bool intensities, bool classifications)
         {
             var reader = new laszip();
             reader.open_reader(filename, out _);
-            return ReadPoints(reader, numberOfPointsPerChunk, verbose);
+            return ReadPoints(reader, numberOfPointsPerChunk, verbose, colors, intensities, classifications);
         }
         /// <summary>
         /// Reads point data from file and returns chunks of given size.
@@ -147,10 +151,14 @@ namespace LASZip
         /// Reads point data from stream and returns chunks of given size.
         /// </summary>
         public static IEnumerable<Points> ReadPoints(Stream stream, int numberOfPointsPerChunk, bool verbose)
+            => ReadPoints(stream, numberOfPointsPerChunk, verbose, colors: true, intensities: true, classifications: true);
+
+        internal static IEnumerable<Points> ReadPoints(Stream stream, int numberOfPointsPerChunk, bool verbose,
+            bool colors, bool intensities, bool classifications)
         {
             var reader = new laszip();
             reader.open_reader_stream(stream, out _, true);
-            return ReadPoints(reader, numberOfPointsPerChunk, verbose);
+            return ReadPoints(reader, numberOfPointsPerChunk, verbose, colors, intensities, classifications);
         }
         /// <summary>
         /// Reads point data from stream and returns chunks of given size.
@@ -158,7 +166,8 @@ namespace LASZip
         public static IEnumerable<Points> ReadPoints(Stream stream, int numberOfPointsPerChunk)
             => ReadPoints(stream, numberOfPointsPerChunk, verbose: false);
 
-        private static IEnumerable<Points> ReadPoints(laszip reader, int numberOfPointsPerChunk, bool verbose)
+        private static IEnumerable<Points> ReadPoints(laszip reader, int numberOfPointsPerChunk, bool verbose,
+            bool readColors, bool readIntensities, bool readClassifications)
         {
             if (numberOfPointsPerChunk < 1) throw new ArgumentOutOfRangeException(nameof(numberOfPointsPerChunk));
 
@@ -178,12 +187,12 @@ namespace LASZip
                 // POINT10
                 var p = new double[3];
                 var ps = new V3d[numberOfPointsPerChunk];
-                var intensities = new ushort[numberOfPointsPerChunk];
+                var intensities = readIntensities ? new ushort[numberOfPointsPerChunk] : null;
                 var returnNumbers = new byte[numberOfPointsPerChunk];
                 var numberOfReturnsOfPulses = new byte[numberOfPointsPerChunk];
                 var scanDirectionFlags = new BitArray(numberOfPointsPerChunk);
                 var edgeOfFlightLines = new BitArray(numberOfPointsPerChunk);
-                var classifications = new byte[numberOfPointsPerChunk];
+                var classifications = readClassifications ? new byte[numberOfPointsPerChunk] : null;
                 var scanAngleRanks = new byte[numberOfPointsPerChunk];
                 var userDatas = new byte[numberOfPointsPerChunk];
                 var pointSourceIds = new ushort[numberOfPointsPerChunk];
@@ -192,7 +201,7 @@ namespace LASZip
                 var gpsTimes = hasGpsTime ? new double[numberOfPointsPerChunk] : null;
 
                 // RGB12
-                var colorsRaw = hasColor ? new C3us[numberOfPointsPerChunk] : null;
+                var colorsRaw = readColors && hasColor ? new C3us[numberOfPointsPerChunk] : null;
                 bool colorIs8Bit = true;
 
                 // WAVEPACKET13
@@ -210,19 +219,19 @@ namespace LASZip
 
                     reader.get_coordinates(p);
                     ps[i] = new V3d(p);
-                    intensities[i] = reader.point.intensity;
+                    if (readIntensities) intensities![i] = reader.point.intensity;
                     returnNumbers[i] = reader.point.return_number;
                     numberOfReturnsOfPulses[i] = Math.Max(reader.point.number_of_returns, reader.point.extended_number_of_returns);
                     scanDirectionFlags[i] = reader.point.scan_direction_flag != 0;
                     edgeOfFlightLines[i] = reader.point.edge_of_flight_line != 0;
-                    classifications[i] = reader.point.classification;
+                    if (readClassifications) classifications![i] = reader.point.classification;
                     scanAngleRanks[i] = (byte)reader.point.scan_angle_rank;
                     userDatas[i] = reader.point.user_data;
                     pointSourceIds[i] = reader.point.point_source_ID;
 
                     if (hasGpsTime) gpsTimes![i] = reader.point.gps_time;
 
-                    if (hasColor)
+                    if (colorsRaw != null)
                     {
                         var c = new C3us(reader.point.rgb[0], reader.point.rgb[1], reader.point.rgb[2]);
                         colorsRaw![i] = c;

--- a/src/Aardvark.Data.Points.Ply/PlyImport.cs
+++ b/src/Aardvark.Data.Points.Ply/PlyImport.cs
@@ -53,13 +53,13 @@ namespace Aardvark.Data.Points.Import
         }
 
         /// <summary>
-        /// Parses PLY (.ply) file.
+        /// Parses a PLY (.ply) file and omits optional standard properties disabled by the configuration.
         /// </summary>
         public static IEnumerable<Chunk> Chunks(string filename, ParseConfig config)
             => PlyParser.Parse(filename, config.MaxChunkPointCount, config.Verbose ? (s => Report.Line(s)) : null).Chunks(config);
 
         /// <summary>
-        /// Parses PLY (.ply) file.
+        /// Parses a PLY (.ply) stream and omits optional standard properties disabled by the configuration.
         /// </summary>
 #pragma warning disable IDE0060 // Remove unused parameter
         public static IEnumerable<Chunk> Chunks(this Stream stream, long streamLengthInBytes, ParseConfig config)
@@ -73,7 +73,7 @@ namespace Aardvark.Data.Points.Import
             => Chunks(data, ParseConfig.Default);
 
         /// <summary>
-        /// Parses Ply.Net dataset.
+        /// Converts a Ply.Net dataset while omitting optional standard properties disabled by the configuration.
         /// </summary>
         public static IEnumerable<Chunk> Chunks(this PlyParser.Dataset data, ParseConfig config)
         {
@@ -121,10 +121,10 @@ namespace Aardvark.Data.Points.Import
 
                 #region colors
 
-                var cr = vd["red"];
-                var cg = vd["green"];
-                var cb = vd["blue"];
-                var ca = vd["alpha"];
+                var cr = config.EnabledProperties.Colors ? vd["red"] : null;
+                var cg = config.EnabledProperties.Colors ? vd["green"] : null;
+                var cb = config.EnabledProperties.Colors ? vd["blue"] : null;
+                var ca = config.EnabledProperties.Colors ? vd["alpha"] : null;
                 var hasColors = cr != null || cg != null || cb != null || ca != null;
                 var cs = hasColors ? new C4b[count] : null;
                 if (hasColors && ca == null) for (var i = 0; i < count; i++) cs![i].A = 255;
@@ -157,9 +157,9 @@ namespace Aardvark.Data.Points.Import
 
                 #region normals
 
-                var nx = vd["nx"];
-                var ny = vd["ny"];
-                var nz = vd["nz"];
+                var nx = config.EnabledProperties.Normals ? vd["nx"] : null;
+                var ny = config.EnabledProperties.Normals ? vd["ny"] : null;
+                var nz = config.EnabledProperties.Normals ? vd["nz"] : null;
                 var hasNormals = nx != null || ny != null || nz != null;
                 var ns = hasNormals ? new V3f[count] : null;
 
@@ -190,7 +190,7 @@ namespace Aardvark.Data.Points.Import
 
                 #region intensities
 
-                var j = vd["scalar_intensity"] ?? vd["intensity"];
+                var j = config.EnabledProperties.Intensities ? vd["scalar_intensity"] ?? vd["intensity"] : null;
                 var hasIntensities = j != null;
                 var js = hasIntensities ? new int[count] : null;
 
@@ -237,7 +237,7 @@ namespace Aardvark.Data.Points.Import
 
                 #region classifications
 
-                var k = vd["scalar_classification"] ?? vd["classification"];
+                var k = config.EnabledProperties.Classifications ? vd["scalar_classification"] ?? vd["classification"] : null;
                 var hasClassification = k != null;
                 var ks = hasClassification ? new byte[count] : null;
 


### PR DESCRIPTION
## Summary
- replace disabled custom ASCII, PTS, and YXH standard-property tokens with `Skip` without mutating caller layouts
- avoid PLY projection and result arrays for disabled colors, normals, intensities, and classifications
- thread LAS/LAZ color, intensity, and classification selection into the internal reader while preserving public `LASZip.Parser.ReadPoints` all-property behavior
- exclude disabled filtered-E57 semantics before buffering and suppress projection/default arrays while preserving validity filtering, mixed-scan defaults, and `ChunksFull`
- keep positions and part-index selection independent of optional standard-property flags
- document importer-wide selection and generated-LoD-normal behavior

## Regression coverage
Twenty-seven focused synthetic and fixture-backed cases cover custom ASCII, PTS, YXH, PLY, LAS, LAZ, and E57 file/stream paths; each property flag independently; all-enabled and all-disabled selection; exact values and aligned lengths; caller-layout immutability; part-index independence; public LAS parser behavior; `E57.ChunksFull`; and high-level imports where LoD generation may synthesize normals.

## Performance
Warmed Release medians used equivalent configurations. All-enabled checksums match before and after.

| Path | All-enabled result | Disabled result | Disabled allocation |
| --- | ---: | ---: | ---: |
| ASCII, 32,768 records | 201.511 → 201.786 ms; allocation unchanged | 201.066 → 201.103 ms | 51,385,016 → 27,004,672 B (-47.4%) |
| PLY projection, 32,768 records | 1.301 → 1.275 ms; allocation unchanged | 1.294 → 0.579 ms | 1,479,304 → 788,872 B (-46.7%) |
| LAS, 500 fixture reads | 8.177 → 8.220 ms; allocation +0.1% | 8.608 → 8.275 ms | 3,769,624 → 3,657,624 B (-3.0%) |
| E57, 25 fixture reads | 3.685 → 3.488 ms; allocation -3.6% | 3.698 → 3.188 ms | 1,470,544 → 1,376,744 B (-6.4%) |

All-enabled throughput is unchanged or improved within measurement noise; disabled paths reduce allocations throughout.

## Validation
- 27 focused selection tests passed
- 125 importer/parser-focused tests passed
- 469 complete-suite tests passed with 2 existing skips
- complete Release solution build passed with warnings treated as errors

Fixes #79.