### PR TITLE
Reject incompatible Chunk merge schemas

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,5 @@
+- [Point Cloud] reject incompatible Chunk merge schemas and treat empty chunks as neutral (#81)
+
 ### 5.6.3
 - Updated SharpCompress to 0.48.1 to address CVE-2026-44788
 

--- a/ai/POINT_CLOUDS.md
+++ b/ai/POINT_CLOUDS.md
@@ -148,6 +148,10 @@ foreach (var subChunk in chunk.Split(chunksize: 4096))
 }
 ```
 
+`Chunk.Union`, `ImmutableMerge`, and `ImmutableMergeWith` require all nonempty inputs to agree on whether colors, normals, intensities, classifications, and part indices are present. A schema mismatch throws `InvalidOperationException` before point or attribute data is copied; optional arrays are never silently dropped or partially aligned. Compatible part-index representations may differ and are concatenated using the smallest supported scalar or array representation.
+
+Empty chunks, including empty chunks carrying optional arrays, are neutral. A composition containing exactly one nonempty chunk returns that object without copying, while an empty or all-empty composition returns the canonical `Chunk.Empty`. These rules also apply when `PointCloud.Chunks` coalesces small input chunks.
+
 ### Accessing Node Attributes
 
 ```csharp

--- a/src/Aardvark.Algodat.Tests/ChunkMergeTests.cs
+++ b/src/Aardvark.Algodat.Tests/ChunkMergeTests.cs
@@ -1,0 +1,381 @@
+﻿/*
+    Copyright (C) 2006-2026. Aardvark Platform Team. http://github.com/aardvark-platform.
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+using Aardvark.Base;
+using Aardvark.Data.Points;
+using Aardvark.Geometry.Points;
+using NUnit.Framework;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Aardvark.Geometry.Tests
+{
+    [TestFixture]
+    public class ChunkMergeTests
+    {
+        public enum OptionalProperty
+        {
+            Colors,
+            Normals,
+            Intensities,
+            Classifications,
+            PartIndices,
+        }
+
+        public enum MergeEntryPoint
+        {
+            BinaryImmutableMerge,
+            ParamsImmutableMerge,
+            EnumerableImmutableMerge,
+            InstanceUnion,
+            EnumerableUnion,
+            ParamsImmutableMergeWith,
+            EnumerableImmutableMergeWith,
+        }
+
+        private static string PropertyName(OptionalProperty property) => property switch
+        {
+            OptionalProperty.Colors => "colors",
+            OptionalProperty.Normals => "normals",
+            OptionalProperty.Intensities => "intensities",
+            OptionalProperty.Classifications => "classifications",
+            OptionalProperty.PartIndices => "part indices",
+            _ => throw new ArgumentOutOfRangeException(nameof(property)),
+        };
+
+        private static Chunk Create(int origin, OptionalProperty? property = null)
+        {
+            var positions = new[]
+            {
+                new V3d(origin, origin + 1, origin + 2),
+                new V3d(origin + 3, origin + 4, origin + 5),
+            };
+            return new Chunk(
+                positions,
+                property == OptionalProperty.Colors ? new[] { new C4b(origin), new C4b(origin + 1) } : null,
+                property == OptionalProperty.Normals ? new[] { new V3f(origin, 1, 0), new V3f(origin + 1, 1, 0) } : null,
+                property == OptionalProperty.Intensities ? new[] { origin + 10, origin + 11 } : null,
+                property == OptionalProperty.Classifications ? new[] { (byte)(origin + 20), (byte)(origin + 21) } : null,
+                property == OptionalProperty.PartIndices ? new byte[] { (byte)(origin + 30), (byte)(origin + 31) } : null,
+                partIndexRange: null,
+                bbox: null
+                );
+        }
+
+        private static Chunk CreateFull(int origin, object partIndices, Box3d? bounds = null)
+        {
+            var count = partIndices switch
+            {
+                IList<byte> xs => xs.Count,
+                IList<short> xs => xs.Count,
+                IList<int> xs => xs.Count,
+                int => 2,
+                uint => 2,
+                _ => throw new ArgumentException("Unsupported part-index representation.", nameof(partIndices)),
+            };
+            var positions = new V3d[count];
+            var colors = new C4b[count];
+            var normals = new V3f[count];
+            var intensities = new int[count];
+            var classifications = new byte[count];
+            for (var i = 0; i < count; i++)
+            {
+                positions[i] = new V3d(origin + i, origin - i, origin * 2 + i);
+                colors[i] = new C4b((byte)(origin + i), (byte)(origin + i + 1), (byte)(origin + i + 2), (byte)255);
+                normals[i] = new V3f(origin + i, 1, -1);
+                intensities[i] = origin * 10 + i;
+                classifications[i] = (byte)(origin + i + 40);
+            }
+            return new Chunk(positions, colors, normals, intensities, classifications, partIndices, null, bounds);
+        }
+
+        private static Chunk AttributeBearingEmpty(Box3d? bounds = null)
+            => new(
+                Array.Empty<V3d>(),
+                Array.Empty<C4b>(),
+                Array.Empty<V3f>(),
+                Array.Empty<int>(),
+                Array.Empty<byte>(),
+                Array.Empty<byte>(),
+                new Range1i(123),
+                bounds ?? new Box3d(new V3d(-100), new V3d(100))
+                );
+
+        private static IEnumerable<TestCaseData> SchemaMismatchCases()
+        {
+            foreach (var entryPoint in Enum.GetValues<MergeEntryPoint>())
+            foreach (var property in Enum.GetValues<OptionalProperty>())
+            foreach (var reverse in new[] { false, true })
+            {
+                yield return new TestCaseData(entryPoint, property, reverse)
+                    .SetName($"SchemaMismatch_{entryPoint}_{property}_{(reverse ? "MissingFirst" : "PresentFirst")}");
+            }
+        }
+
+        [TestCaseSource(nameof(SchemaMismatchCases))]
+        public void SchemaMismatchIsRejectedInBothOrders(
+            MergeEntryPoint entryPoint, OptionalProperty property, bool reverse)
+        {
+            var present = Create(0, property);
+            var missing = Create(10);
+            var first = reverse ? missing : present;
+            var second = reverse ? present : missing;
+            var empty = AttributeBearingEmpty();
+
+            Chunk Merge() => entryPoint switch
+            {
+                MergeEntryPoint.BinaryImmutableMerge => Chunk.ImmutableMerge(first, second),
+                MergeEntryPoint.ParamsImmutableMerge => Chunk.ImmutableMerge(first, empty, second),
+                MergeEntryPoint.EnumerableImmutableMerge => Chunk.ImmutableMerge((IEnumerable<Chunk>)new[] { first, empty, second }),
+                MergeEntryPoint.InstanceUnion => first.Union(second),
+                MergeEntryPoint.EnumerableUnion => new[] { first, empty, second }.AsEnumerable().Union(),
+                MergeEntryPoint.ParamsImmutableMergeWith => first.ImmutableMergeWith(empty, second),
+                MergeEntryPoint.EnumerableImmutableMergeWith => first.ImmutableMergeWith((IEnumerable<Chunk>)new[] { empty, second }),
+                _ => throw new ArgumentOutOfRangeException(nameof(entryPoint)),
+            };
+
+            var error = Assert.Throws<InvalidOperationException>(() => Merge());
+            Assert.That(error!.Message, Does.Contain("nonempty chunks"));
+            Assert.That(error.Message, Does.Contain(PropertyName(property)));
+            Assert.That(present.Count, Is.EqualTo(2));
+            Assert.That(missing.Count, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void EmptyChunksAreNeutralAndAllEmptyInputsAreCanonical()
+        {
+            var empty0 = AttributeBearingEmpty();
+            var empty1 = AttributeBearingEmpty(new Box3d(new V3d(-1000), new V3d(1000)));
+            var value = CreateFull(1, 7);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(Chunk.ImmutableMerge(value), Is.SameAs(value));
+                Assert.That(Chunk.ImmutableMerge((IEnumerable<Chunk>)new[] { value }), Is.SameAs(value));
+                Assert.That(Chunk.ImmutableMerge(empty0, value), Is.SameAs(value));
+                Assert.That(Chunk.ImmutableMerge(value, empty0), Is.SameAs(value));
+                Assert.That(empty0.Union(value), Is.SameAs(value));
+                Assert.That(value.Union(empty0), Is.SameAs(value));
+                Assert.That(Chunk.ImmutableMerge(empty0, value, empty1), Is.SameAs(value));
+                Assert.That(Chunk.ImmutableMerge((IEnumerable<Chunk>)new[] { empty0, value, empty1 }), Is.SameAs(value));
+                Assert.That(new[] { empty0, value, empty1 }.AsEnumerable().Union(), Is.SameAs(value));
+                Assert.That(empty0.ImmutableMergeWith(value, empty1), Is.SameAs(value));
+                Assert.That(empty0.ImmutableMergeWith((IEnumerable<Chunk>)new[] { value, empty1 }), Is.SameAs(value));
+                Assert.That(value.ImmutableMergeWith(empty0, empty1), Is.SameAs(value));
+                Assert.That(value.ImmutableMergeWith((IEnumerable<Chunk>)new[] { empty0, empty1 }), Is.SameAs(value));
+
+                Assert.That(Chunk.ImmutableMerge(empty0), Is.SameAs(Chunk.Empty));
+                Assert.That(Chunk.ImmutableMerge((IEnumerable<Chunk>)new[] { empty0 }), Is.SameAs(Chunk.Empty));
+                Assert.That(empty0.ImmutableMergeWith(Array.Empty<Chunk>()), Is.SameAs(Chunk.Empty));
+                Assert.That(Chunk.ImmutableMerge(empty0, empty1), Is.SameAs(Chunk.Empty));
+                Assert.That(empty0.Union(empty1), Is.SameAs(Chunk.Empty));
+                Assert.That(Chunk.ImmutableMerge(empty0, Chunk.Empty, empty1), Is.SameAs(Chunk.Empty));
+                Assert.That(Chunk.ImmutableMerge((IEnumerable<Chunk>)new[] { empty0, empty1 }), Is.SameAs(Chunk.Empty));
+                Assert.That(new[] { empty0, empty1 }.AsEnumerable().Union(), Is.SameAs(Chunk.Empty));
+                Assert.That(empty0.ImmutableMergeWith(empty1), Is.SameAs(Chunk.Empty));
+                Assert.That(empty0.ImmutableMergeWith((IEnumerable<Chunk>)new[] { empty1 }), Is.SameAs(Chunk.Empty));
+                Assert.That(Chunk.ImmutableMerge(Array.Empty<Chunk>()), Is.SameAs(Chunk.Empty));
+                Assert.That(Chunk.ImmutableMerge(Enumerable.Empty<Chunk>()), Is.SameAs(Chunk.Empty));
+            });
+        }
+
+        [Test]
+        public void CompatibleMergesPreserveValuesOrderBoundsAndSources()
+        {
+            var boundsA = new Box3d(new V3d(-10, -9, -8), new V3d(2, 3, 4));
+            var boundsB = new Box3d(new V3d(5, 6, 7), new V3d(20, 21, 22));
+            var a = CreateFull(1, 7, boundsA);
+            var b = CreateFull(5, new byte[] { 8, 9 }, boundsB);
+            var empty = AttributeBearingEmpty();
+
+            var originalPositionsA = a.Positions.ToArray();
+            var originalColorsA = a.Colors!.ToArray();
+            var originalNormalsA = a.Normals!.ToArray();
+            var originalIntensitiesA = a.Intensities!.ToArray();
+            var originalClassificationsA = a.Classifications!.ToArray();
+            var originalPartsA = PartIndexUtils.Expand(a.PartIndices, a.Count)!;
+            var expectedPositions = a.Positions.Concat(b.Positions).ToArray();
+            var expectedColors = a.Colors.Concat(b.Colors!).ToArray();
+            var expectedNormals = a.Normals.Concat(b.Normals!).ToArray();
+            var expectedIntensities = a.Intensities.Concat(b.Intensities!).ToArray();
+            var expectedClassifications = a.Classifications.Concat(b.Classifications!).ToArray();
+            var expectedParts = new[] { 7, 7, 8, 9 };
+            var expectedBounds = new Box3d(boundsA, boundsB);
+
+            var results = new[]
+            {
+                Chunk.ImmutableMerge(a, b),
+                Chunk.ImmutableMerge(a, empty, b),
+                Chunk.ImmutableMerge((IEnumerable<Chunk>)new[] { a, empty, b }),
+                a.Union(b),
+                new[] { a, empty, b }.AsEnumerable().Union(),
+                a.ImmutableMergeWith(empty, b),
+                a.ImmutableMergeWith((IEnumerable<Chunk>)new[] { empty, b }),
+            };
+
+            foreach (var result in results)
+            {
+                Assert.That(result.Positions, Is.EqualTo(expectedPositions));
+                Assert.That(result.Colors, Is.EqualTo(expectedColors));
+                Assert.That(result.Normals, Is.EqualTo(expectedNormals));
+                Assert.That(result.Intensities, Is.EqualTo(expectedIntensities));
+                Assert.That(result.Classifications, Is.EqualTo(expectedClassifications));
+                Assert.That(PartIndexUtils.Expand(result.PartIndices, result.Count), Is.EqualTo(expectedParts));
+                Assert.That(result.PartIndexRange, Is.EqualTo(new Range1i(7, 9)));
+                Assert.That(result.BoundingBox, Is.EqualTo(expectedBounds));
+            }
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(a.Positions, Is.EqualTo(originalPositionsA));
+                Assert.That(a.Colors, Is.EqualTo(originalColorsA));
+                Assert.That(a.Normals, Is.EqualTo(originalNormalsA));
+                Assert.That(a.Intensities, Is.EqualTo(originalIntensitiesA));
+                Assert.That(a.Classifications, Is.EqualTo(originalClassificationsA));
+                Assert.That(PartIndexUtils.Expand(a.PartIndices, a.Count), Is.EqualTo(originalPartsA));
+                Assert.That(a.BoundingBox, Is.EqualTo(boundsA));
+                Assert.That(b.BoundingBox, Is.EqualTo(boundsB));
+            });
+        }
+
+        private static IEnumerable<TestCaseData> PartIndexCases()
+        {
+            yield return new TestCaseData(7, 3, 7, 2, typeof(int), new[] { 7, 7, 7, 7, 7 })
+                .SetName("PartIndices_EqualIntScalarsStayScalar");
+            yield return new TestCaseData((uint)7, 3, (uint)7, 2, typeof(uint), new[] { 7, 7, 7, 7, 7 })
+                .SetName("PartIndices_EqualUIntScalarsStayScalar");
+            yield return new TestCaseData(1, 2, 2, 2, typeof(byte[]), new[] { 1, 1, 2, 2 })
+                .SetName("PartIndices_SmallScalarsCompactToBytes");
+            yield return new TestCaseData(300, 2, new byte[] { 1, 2 }, 2, typeof(short[]), new[] { 300, 300, 1, 2 })
+                .SetName("PartIndices_ScalarAndBytesPromoteToShorts");
+            yield return new TestCaseData(new byte[] { 1, 250 }, 2, new short[] { 300, 2 }, 2, typeof(short[]), new[] { 1, 250, 300, 2 })
+                .SetName("PartIndices_BytesAndShortsUseShorts");
+            yield return new TestCaseData(new short[] { 1, 300 }, 2, new[] { 40000, 2 }, 2, typeof(int[]), new[] { 1, 300, 40000, 2 })
+                .SetName("PartIndices_ShortsAndIntsUseInts");
+        }
+
+        [TestCaseSource(nameof(PartIndexCases))]
+        public void CompatiblePartIndexRepresentationsRemainCompactAndTyped(
+            object firstParts, int firstCount, object secondParts, int secondCount,
+            Type expectedType, int[] expectedValues)
+        {
+            var first = CreatePositionsWithParts(0, firstCount, firstParts);
+            var second = CreatePositionsWithParts(firstCount, secondCount, secondParts);
+            var results = new[]
+            {
+                Chunk.ImmutableMerge(first, second),
+                Chunk.ImmutableMerge(first, AttributeBearingEmpty(), second),
+                first.Union(second),
+            };
+
+            foreach (var result in results)
+            {
+                Assert.That(result.PartIndices, Is.TypeOf(expectedType));
+                Assert.That(PartIndexUtils.Expand(result.PartIndices, result.Count), Is.EqualTo(expectedValues));
+                Assert.That(result.PartIndexRange, Is.EqualTo(new Range1i(expectedValues)));
+            }
+        }
+
+        private static Chunk CreatePositionsWithParts(int origin, int count, object partIndices)
+            => new(
+                Enumerable.Range(origin, count).Select(i => new V3d(i, i * 2, -i)).ToArray(),
+                colors: null,
+                normals: null,
+                intensities: null,
+                classifications: null,
+                partIndices,
+                partIndexRange: null,
+                bbox: null
+                );
+
+        [Test]
+        public void NWayCompositionValidatesEverySchemaBeforeReadingPointData()
+        {
+            var unreadable = new Chunk(
+                new UnreadableList<V3d>(1),
+                new UnreadableList<C4b>(1),
+                normals: null,
+                intensities: null,
+                classifications: null,
+                partIndices: null,
+                partIndexRange: null,
+                bbox: new Box3d(V3d.Zero)
+                );
+            var compatible = Create(10, OptionalProperty.Colors);
+            var incompatible = Create(20);
+
+            foreach (var merge in new Func<Chunk>[]
+            {
+                () => Chunk.ImmutableMerge(unreadable, compatible, incompatible),
+                () => Chunk.ImmutableMerge((IEnumerable<Chunk>)new[] { unreadable, compatible, incompatible }),
+                () => new[] { unreadable, compatible, incompatible }.AsEnumerable().Union(),
+                () => unreadable.ImmutableMergeWith(compatible, incompatible),
+                () => unreadable.ImmutableMergeWith((IEnumerable<Chunk>)new[] { compatible, incompatible }),
+            })
+            {
+                var error = Assert.Throws<InvalidOperationException>(() => merge());
+                Assert.That(error!.Message, Does.Contain("colors"));
+            }
+        }
+
+        [TestCase(false)]
+        [TestCase(true)]
+        public void PointCloudChunksSurfacesMergeSmallSchemaMismatch(bool reverse)
+        {
+            var withColors = Create(0, OptionalProperty.Colors);
+            var withoutColors = Create(10);
+            var chunks = reverse
+                ? new[] { withoutColors, withColors }
+                : new[] { withColors, withoutColors };
+            var config = ImportConfig.Default
+                .WithStorage(PointSetTests.CreateStorage())
+                .WithMaxChunkPointCount(1024)
+                .WithOctreeSplitLimit(16)
+                .WithMinDist(0)
+                .WithNormalizePointDensityGlobal(false)
+                .WithMaxDegreeOfParallelism(1)
+                .WithEnabledPartIndices(false)
+                .WithVerbose(false);
+
+            var error = Assert.Throws<InvalidOperationException>(() => PointCloud.Chunks(chunks, config));
+            Assert.That(error!.Message, Does.Contain("nonempty chunks"));
+            Assert.That(error.Message, Does.Contain("colors"));
+        }
+
+        private sealed class UnreadableList<T> : IList<T>
+        {
+            public UnreadableList(int count) => Count = count;
+
+            public T this[int index]
+            {
+                get => throw new InvalidOperationException("Point data was read before all schemas were validated.");
+                set => throw new NotSupportedException();
+            }
+
+            public int Count { get; }
+            public bool IsReadOnly => true;
+            public void Add(T item) => throw new NotSupportedException();
+            public void Clear() => throw new NotSupportedException();
+            public bool Contains(T item) => throw new NotSupportedException();
+            public void CopyTo(T[] array, int arrayIndex) => throw new InvalidOperationException("Point data was copied before all schemas were validated.");
+            public IEnumerator<T> GetEnumerator() => throw new InvalidOperationException("Point data was enumerated before all schemas were validated.");
+            public int IndexOf(T item) => throw new NotSupportedException();
+            public void Insert(int index, T item) => throw new NotSupportedException();
+            public bool Remove(T item) => throw new NotSupportedException();
+            public void RemoveAt(int index) => throw new NotSupportedException();
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        }
+    }
+}

--- a/src/Aardvark.Data.Points.Base/Chunk.cs
+++ b/src/Aardvark.Data.Points.Base/Chunk.cs
@@ -21,6 +21,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 
 #pragma warning disable CS1591
@@ -28,7 +29,9 @@ using System.Threading.Tasks;
 namespace Aardvark.Data.Points
 {
     /// <summary>
-    /// Parsers emit a sequence of chunks of points with optional colors, normals, and intensities.
+    /// Parsers emit a sequence of chunks of points with optional colors, normals, intensities,
+    /// classifications, and part indices. Composition requires every nonempty chunk to have the
+    /// same optional-property presence; empty chunks are neutral.
     /// </summary>
     public class Chunk
     {
@@ -45,6 +48,9 @@ namespace Aardvark.Data.Points
             return ll;
         }
 
+        /// <summary>
+        /// Canonical empty chunk and the result of composing an empty or all-empty input.
+        /// </summary>
         public static readonly Chunk Empty = new(Array.Empty<V3d>(), null, null, null, null, null, null, Box3d.Invalid);
 
         public readonly IList<V3d> Positions;
@@ -100,10 +106,48 @@ namespace Aardvark.Data.Points
             return PartIndexUtils.Expand(PartIndices, Count);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int GetMergeSchema(Chunk chunk)
+            => (chunk.Colors != null ? 1 : 0) |
+               (chunk.Normals != null ? 2 : 0) |
+               (chunk.Intensities != null ? 4 : 0) |
+               (chunk.Classifications != null ? 8 : 0) |
+               (chunk.PartIndices != null ? 16 : 0);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void ValidateMergeSchema(Chunk expected, Chunk actual)
+        {
+            var differences = GetMergeSchema(expected) ^ GetMergeSchema(actual);
+            if (differences != 0) ThrowMergeSchemaMismatch(differences);
+        }
+
+        [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void ThrowMergeSchemaMismatch(int differences)
+        {
+            var names = new List<string>(5);
+            if ((differences & 1) != 0) names.Add("colors");
+            if ((differences & 2) != 0) names.Add("normals");
+            if ((differences & 4) != 0) names.Add("intensities");
+            if ((differences & 8) != 0) names.Add("classifications");
+            if ((differences & 16) != 0) names.Add("part indices");
+
+            throw new InvalidOperationException(
+                $"Cannot merge nonempty chunks with different optional properties: {string.Join(", ", names)}. " +
+                "Each property must either be present in every nonempty chunk or absent from every nonempty chunk."
+                );
+        }
+
+        /// <summary>
+        /// Merges two chunks without modifying them. Empty chunks are neutral. Nonempty chunks
+        /// must have matching optional-property presence or an <see cref="InvalidOperationException"/> is thrown.
+        /// </summary>
         public static Chunk ImmutableMerge(Chunk a, Chunk b)
         {
-            if (a is null || a.IsEmpty) return b;
+            if (a is null || a.IsEmpty) return b is null || b.IsEmpty ? Empty : b;
             if (b is null || b.IsEmpty) return a;
+
+            ValidateMergeSchema(a, b);
 
             ImmutableList<V3d> ps;
             {
@@ -116,60 +160,32 @@ namespace Aardvark.Data.Points
             if (a.HasColors)
             {
                 var cs0 = (a.Colors is ImmutableList<C4b> x2) ? x2 : [.. a.Colors];
-                if (b.HasColors)
-                {
-                    var cs1 = (b.Colors is ImmutableList<C4b> x3) ? x3 : [.. b.Colors];
-                    cs = cs0.AddRange(cs1);
-                }
-                else
-                {
-                    cs = cs0;
-                }
+                var cs1 = (b.Colors is ImmutableList<C4b> x3) ? x3 : [.. b.Colors!];
+                cs = cs0.AddRange(cs1);
             }
 
             ImmutableList<V3f>? ns = null;
             if (a.HasNormals)
             {
                 var ns0 = (a.Normals is ImmutableList<V3f> x4) ? x4 : [.. a.Normals];
-                if (b.HasNormals)
-                {
-                    var ns1 = (b.Normals is ImmutableList<V3f> x5) ? x5 : [.. b.Normals];
-                    ns = ns0.AddRange(ns1);
-                }
-                else
-                {
-                    ns = ns0;
-                }
+                var ns1 = (b.Normals is ImmutableList<V3f> x5) ? x5 : [.. b.Normals!];
+                ns = ns0.AddRange(ns1);
             }
 
             ImmutableList<int>? js = null;
             if (a.HasIntensities)
             {
                 var js0 = (a.Intensities is ImmutableList<int> x6) ? x6 : [.. a.Intensities];
-                if (b.HasIntensities)
-                {
-                    var js1 = (b.Intensities is ImmutableList<int> x7) ? x7 : [.. b.Intensities];
-                    js = js0.AddRange(js1);
-                }
-                else
-                {
-                    js = js0;
-                }
+                var js1 = (b.Intensities is ImmutableList<int> x7) ? x7 : [.. b.Intensities!];
+                js = js0.AddRange(js1);
             }
 
             ImmutableList<byte>? ks = null;
             if (a.HasClassifications)
             {
                 var ks0 = (a.Classifications is ImmutableList<byte> x8) ? x8 : [.. a.Classifications];
-                if (b.HasClassifications)
-                {
-                    var ks1 = (b.Classifications is ImmutableList<byte> x9) ? x9 : [.. b.Classifications];
-                    ks = ks0.AddRange(ks1);
-                }
-                else
-                {
-                    ks = ks0;
-                }
+                var ks1 = (b.Classifications is ImmutableList<byte> x9) ? x9 : [.. b.Classifications!];
+                ks = ks0.AddRange(ks1);
             }
 
             var qs = PartIndexUtils.ConcatIndices(a.PartIndices, a.Count, b.PartIndices, b.Count);
@@ -178,13 +194,43 @@ namespace Aardvark.Data.Points
             return new Chunk(ps, cs, ns, js, ks, qs, qsRange, new Box3d(a.BoundingBox, b.BoundingBox));
         }
 
+        /// <summary>
+        /// Merges chunks without modifying them. Empty chunks are neutral and an all-empty input
+        /// returns <see cref="Empty"/>. Nonempty chunks must have matching optional-property presence.
+        /// A single nonempty chunk is returned unchanged.
+        /// </summary>
         public static Chunk ImmutableMerge(params Chunk[] chunks)
-        {
-            if (chunks == null || chunks.Length == 0) return Empty;
-            if (chunks.Length == 1) return chunks[0];
+            => chunks == null ? Empty : ImmutableMergeCore(chunks);
 
-            var head = chunks[0];
-            var totalCount = chunks.Sum(c => c.Count);
+        private static Chunk ImmutableMergeCore(IReadOnlyList<Chunk> chunks)
+        {
+            Chunk? head = null;
+            var nonemptyCount = 0;
+            var totalCount = 0;
+            var totalBounds = Box3d.Invalid;
+
+            for (var i = 0; i < chunks.Count; i++)
+            {
+                var chunk = chunks[i] ?? throw new ArgumentException($"Chunk at index {i} is null.", nameof(chunks));
+                if (chunk.IsEmpty) continue;
+
+                if (head == null)
+                {
+                    head = chunk;
+                    totalBounds = chunk.BoundingBox;
+                }
+                else
+                {
+                    ValidateMergeSchema(head, chunk);
+                    totalBounds = new Box3d(totalBounds, chunk.BoundingBox);
+                }
+
+                checked { totalCount += chunk.Count; }
+                nonemptyCount++;
+            }
+
+            if (head == null) return Empty;
+            if (nonemptyCount == 1) return head;
 
             var ps = new V3d[totalCount];
             var cs = head.HasColors ? new C4b[totalCount] : null;
@@ -192,31 +238,39 @@ namespace Aardvark.Data.Points
             var js = head.HasIntensities ? new int[totalCount] : null;
             var ks = head.HasClassifications ? new byte[totalCount] : null;
 
+            object? qs = null;
+            Range1i? qsRange = null;
             var offset = 0;
-            foreach (var chunk in chunks)
+            for (var i = 0; i < chunks.Count; i++)
             {
+                var chunk = chunks[i];
                 if (chunk.IsEmpty) continue;
 
-#pragma warning disable CS8602
-                if (ps != null) chunk.Positions.CopyTo(ps, offset);
-                if (cs != null) chunk.Colors.CopyTo(cs, offset);
-                if (ns != null) chunk.Normals.CopyTo(ns, offset);
-                if (js != null) chunk.Intensities.CopyTo(js, offset);
-                if (ks != null) chunk.Classifications.CopyTo(ks, offset);
-#pragma warning restore CS8602
+                chunk.Positions.CopyTo(ps, offset);
+                if (cs != null) chunk.Colors!.CopyTo(cs, offset);
+                if (ns != null) chunk.Normals!.CopyTo(ns, offset);
+                if (js != null) chunk.Intensities!.CopyTo(js, offset);
+                if (ks != null) chunk.Classifications!.CopyTo(ks, offset);
 
+                qs = PartIndexUtils.ConcatIndices(qs, offset, chunk.PartIndices, chunk.Count);
+                qsRange = PartIndexUtils.MergeRanges(qsRange, chunk.PartIndexRange);
                 offset += chunk.Count;
             }
 
-            if (ps == null) throw new Exception("Invariant 4cc7d585-9a46-4ba2-892a-95fce9ed06da.");
-
-            var qs = PartIndexUtils.ConcatIndices(chunks.Select(x => (indices: x.PartIndices, count: x.Count)));
-            var qsRanges = PartIndexUtils.MergeRanges(chunks.Select(x => x.PartIndexRange));
-            return new Chunk(ps, cs, ns, js, ks, qs, qsRanges, bbox: new Box3d(chunks.Select(x => x.BoundingBox)));
+            return new Chunk(ps, cs, ns, js, ks, qs, qsRange, totalBounds);
         }
 
+        /// <summary>
+        /// Merges a sequence of chunks according to the same schema and empty-input contract as
+        /// <see cref="ImmutableMerge(Chunk[])"/>.
+        /// </summary>
         public static Chunk ImmutableMerge(IEnumerable<Chunk> chunks)
-            => ImmutableMerge([.. chunks]);
+        {
+            if (chunks == null) throw new ArgumentNullException(nameof(chunks));
+            return chunks is IReadOnlyList<Chunk> list
+                ? ImmutableMergeCore(list)
+                : ImmutableMergeCore(chunks.ToArray());
+        }
 
         /// <summary>
         /// </summary>
@@ -383,11 +437,15 @@ namespace Aardvark.Data.Points
         }
 
         /// <summary>
-        /// Creates new chunk which is union of this chunk and other. 
+        /// Creates a new chunk which is the union of this chunk and <paramref name="other"/>.
+        /// Empty chunks are neutral. Nonempty chunks must have matching optional-property presence.
         /// </summary>
         public Chunk Union(Chunk other)
         {
+            if (IsEmpty) return other.IsEmpty ? Empty : other;
             if (other.IsEmpty) return this;
+
+            ValidateMergeSchema(this, other);
 
             var ps = Append(Positions, other.Positions);
             return ps == null
@@ -488,11 +546,31 @@ namespace Aardvark.Data.Points
         public Chunk ImmutableMapPositions(Func<V3d, V3d> mapping)
             => IsEmpty ? Empty : new(Positions.Map(mapping), Colors, Normals, Intensities, Classifications, PartIndices, PartIndexRange, BoundingBox);
 
+        /// <summary>
+        /// Merges this chunk and a sequence of chunks without modifying them. Empty chunks are neutral;
+        /// nonempty chunks must have matching optional-property presence.
+        /// </summary>
         public Chunk ImmutableMergeWith(IEnumerable<Chunk> others)
-            => ImmutableMerge(this, ImmutableMerge(others));
+        {
+            if (others == null) throw new ArgumentNullException(nameof(others));
+            var chunks = new List<Chunk> { this };
+            chunks.AddRange(others);
+            return ImmutableMergeCore(chunks);
+        }
 
+        /// <summary>
+        /// Merges this chunk and the supplied chunks without modifying them. Empty chunks are neutral;
+        /// nonempty chunks must have matching optional-property presence.
+        /// </summary>
         public Chunk ImmutableMergeWith(params Chunk[] others)
-            => ImmutableMerge(this, ImmutableMerge(others));
+        {
+            if (others == null || others.Length == 0) return IsEmpty ? Empty : this;
+
+            var chunks = new Chunk[others.Length + 1];
+            chunks[0] = this;
+            Array.Copy(others, 0, chunks, 1, others.Length);
+            return ImmutableMergeCore(chunks);
+        }
 
         /// <summary>
         /// Splits this chunk into multiple chunks according to key of i-th point in chunk.

--- a/src/Aardvark.Data.Points.Base/Unmix.cs
+++ b/src/Aardvark.Data.Points.Base/Unmix.cs
@@ -274,13 +274,10 @@ namespace Aardvark.Data.Points
         }
 
         /// <summary>
-        /// Merges many chunks into a single chunk. 
+        /// Merges many chunks into a single chunk. Empty chunks are neutral; nonempty chunks must
+        /// have matching optional-property presence.
         /// </summary>
         public static Chunk Union(this IEnumerable<Chunk> chunks)
-        {
-            var result = Chunk.Empty;
-            foreach (var chunk in chunks) result = result.Union(chunk);
-            return result;
-        }
+            => Chunk.ImmutableMerge(chunks);
     }
 }


### PR DESCRIPTION
## Summary
- require nonempty chunks to agree on color, normal, intensity, classification, and part-index presence across binary/N-way `ImmutableMerge`, instance/enumerable `Union`, and both `ImmutableMergeWith` overloads
- validate a complete N-way schema before allocating result arrays or reading point data, with property-specific `InvalidOperationException` messages
- make canonical and attribute-bearing empty chunks neutral, return `Chunk.Empty` for all-empty inputs, and retain zero-copy identity for one nonempty chunk
- preserve compatible point/attribute order, bounds, source immutability, and compact scalar/byte/short/int part-index concatenation
- surface the same deterministic schema failure when `PointCloud.Chunks` coalesces small chunks
- document the composition contract and empty identity semantics

## Regression coverage
Eighty-one focused cases cover every optional property in both operand orders across seven composition entry points, empty placement and canonical all-empty results, single-nonempty identity, compatible value alignment and bounds, source immutability, part-index representations, validation-before-read behavior, and both `PointCloud.Chunks` input orders.

## Performance
Warmed Release medians used compatible 2,048-point inputs with all optional properties and matching checksums.

| Path | Before | After | Allocation |
| --- | ---: | ---: | ---: |
| Binary merge | 0.366 ms | 0.350 ms (-4.4%) | 624,368 B unchanged |
| Eight-way merge | 0.215 ms | 0.215 ms (+0.2%) | 101,832 → 101,536 B |

## Validation
- 81 focused merge tests passed
- 523 complete-suite tests passed with 2 existing skips
- complete Release solution build passed with warnings treated as errors

Fixes #81.