### PR TITLE
Repair PolyMesh topology traversal

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,5 @@
+- [PolyMesh] repair topology component traversal and endpoint edge neighborhoods (#83)
+
 ### 5.6.3
 - Updated SharpCompress to 0.48.1 to address CVE-2026-44788
 

--- a/ai/POLYMESH.md
+++ b/ai/POLYMESH.md
@@ -189,21 +189,29 @@ Half-edge topology must be built explicitly before accessing edges.
 mesh.BuildTopology();
 
 // Traverse edges around a face
-var face = mesh.Faces[0];
+var face = mesh.GetFace(0);
 foreach (var edge in face.Edges)
 {
     var start = edge.FromVertex.Position;
     var end = edge.ToVertex.Position;
-    var opposite = edge.Opposite; // may be null on boundary
+    var opposite = edge.Opposite;
 }
 
 // Traverse edges around a vertex
-var vertex = mesh.Vertices[0];
-foreach (var edge in vertex.OutgoingEdges)
+var vertex = mesh.GetVertex(0);
+foreach (var edge in vertex.Edges)
 {
-    var neighbor = edge.ToVertex;
+    var neighbor = edge.GetOppositeVertex(vertex);
 }
+
+// Enumerate this edge's other neighbors at one endpoint
+var selected = face.Edge(0);
+var neighbors = selected.GetConnectedEdgesAt(selected.FromVertex);
 ```
+
+`Analyze` and all edge/vertex topology traversal require `BuildTopology()` first. Components are connected through shared edges, not merely shared vertices. `Analyze(out components)` does not cross non-manifold edge links; `Analyze(out components, out reversed)` follows those links and marks faces whose winding differs from the lowest-indexed face in each component.
+
+`ManifoldCopy()` applies that reversal array while preserving face order, but deliberately returns a mesh without built topology. Call `BuildTopology()` on the result before further topology queries. `Edge.GetConnectedEdgesAt` excludes the selected edge and returns each other incident edge once only when the supplied vertex is one of its endpoints; unrelated vertices produce an empty sequence.
 
 ## Attributes
 
@@ -264,7 +272,7 @@ mesh.FaceVertexAttributes[-MyTemperature] = tempIndices;
 7. **Vertex clustering can throw** - Use try-catch when clustering with small delta values.
 8. **SubSetOfFaces compactVertices flag** - `true` reindexes vertices, `false` preserves original indices.
 9. **Group() requires matching attributes** - All meshes must have same attribute keys or operation fails.
-10. **FaceReversedCopy() blindly flips** - Analyze orientation first (check normals vs face winding), don't flip unnecessarily.
+10. **FaceReversedCopy() follows its selector exactly** - Build topology and use `Analyze(..., out reversed)` when reversal should be derived from face connectivity and winding.
 
 ## See Also
 

--- a/src/Aardvark.Algodat.Tests/PolyMesh/PolyMeshTopologyTests.cs
+++ b/src/Aardvark.Algodat.Tests/PolyMesh/PolyMeshTopologyTests.cs
@@ -1,0 +1,242 @@
+﻿using Aardvark.Base;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Aardvark.Geometry.Tests
+{
+    [TestFixture]
+    public class PolyMeshTopologyTests
+    {
+        private static int[] Rotated(int[] values, int offset)
+            => Enumerable.Range(0, values.Length).Select(i => values[(i + offset) % values.Length]).ToArray();
+
+        private static PolyMesh CreateMesh(int vertexCount, params int[][] faces)
+        {
+            var mesh = new PolyMesh();
+            for (var i = 0; i < vertexCount; i++)
+                mesh.AddVertex(new V3d(i % 4, i / 4, (i * 7) % 3));
+            foreach (var face in faces) mesh.AddFace(face);
+            return mesh;
+        }
+
+        private static IEnumerable<TestCaseData> EveryFaceSideCases()
+        {
+            foreach (var valence in new[] { 4, 5 })
+            for (var side = 0; side < valence; side++)
+            {
+                yield return new TestCaseData(valence, side)
+                    .SetName($"Analyze_SharedEdge_{valence}Sides_Side{side}");
+            }
+        }
+
+        [TestCaseSource(nameof(EveryFaceSideCases))]
+        public void AnalyzeFindsSharedEdgeAtEverySideOfEvenAndOddFaces(int valence, int sharedSide)
+        {
+            var primary = Enumerable.Range(0, valence).ToArray();
+            var from = primary[sharedSide];
+            var to = primary[(sharedSide + 1) % valence];
+            var mesh = CreateMesh(valence + 1, primary, new[] { to, from, valence });
+            mesh.BuildTopology();
+
+            var componentCount = mesh.Analyze(out var components);
+            var orientedComponentCount = mesh.Analyze(out var orientedComponents, out var reversed);
+            var sharedEdge = mesh.GetFace(0).Edge(sharedSide);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(componentCount, Is.EqualTo(1));
+                Assert.That(components, Is.EqualTo(new uint[] { 0, 0 }));
+                Assert.That(orientedComponentCount, Is.EqualTo(1));
+                Assert.That(orientedComponents, Is.EqualTo(new uint[] { 0, 0 }));
+                Assert.That(reversed, Is.EqualTo(new[] { false, false }));
+                Assert.That(sharedEdge.Faces.Select(f => f.Index), Is.EquivalentTo(new[] { 0, 1 }));
+                Assert.That(sharedEdge.Faces.Select(f => f.Index).Distinct().Count(), Is.EqualTo(2));
+            });
+        }
+
+        private static IEnumerable<TestCaseData> RotatedMixedFaceCases()
+        {
+            for (var firstRotation = 0; firstRotation < 4; firstRotation++)
+            for (var secondRotation = 0; secondRotation < 5; secondRotation++)
+            {
+                yield return new TestCaseData(firstRotation, secondRotation)
+                    .SetName($"Analyze_MixedFaces_Rotated_{firstRotation}_{secondRotation}");
+            }
+        }
+
+        [TestCaseSource(nameof(RotatedMixedFaceCases))]
+        public void AnalyzeHandlesMixedFaceSizesDisconnectedComponentsAndRotatedStarts(
+            int firstRotation, int secondRotation)
+        {
+            var first = Rotated(new[] { 0, 1, 2, 3 }, firstRotation);
+            var second = Rotated(new[] { 2, 1, 4, 5, 6 }, secondRotation);
+            var isolated = new[] { 7, 8, 9 };
+            var mesh = CreateMesh(10, first, second, isolated);
+            mesh.BuildTopology();
+
+            var componentCount = mesh.Analyze(out var components);
+            var orientedComponentCount = mesh.Analyze(out var orientedComponents, out var reversed);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(componentCount, Is.EqualTo(2));
+                Assert.That(components, Is.EqualTo(new uint[] { 0, 0, 1 }));
+                Assert.That(orientedComponentCount, Is.EqualTo(2));
+                Assert.That(orientedComponents, Is.EqualTo(new uint[] { 0, 0, 1 }));
+                Assert.That(reversed, Is.EqualTo(new[] { false, false, false }));
+            });
+        }
+
+        [Test]
+        public void AnalyzeSeedsEachDisconnectedComponentWithItsOwnFaceSize()
+        {
+            var isolatedTriangle = new[] { 0, 1, 2 };
+            var quad = new[] { 3, 4, 5, 6 };
+            var connectedPentagon = new[] { 3, 6, 7, 8, 9 };
+            var mesh = CreateMesh(10, isolatedTriangle, quad, connectedPentagon);
+            mesh.BuildTopology();
+
+            var componentCount = mesh.Analyze(out var components);
+            var orientedComponentCount = mesh.Analyze(out var orientedComponents, out var reversed);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(componentCount, Is.EqualTo(2));
+                Assert.That(components, Is.EqualTo(new uint[] { 0, 1, 1 }));
+                Assert.That(orientedComponentCount, Is.EqualTo(2));
+                Assert.That(orientedComponents, Is.EqualTo(new uint[] { 0, 1, 1 }));
+                Assert.That(reversed, Is.EqualTo(new[] { false, false, false }));
+            });
+        }
+
+        [Test]
+        public void AnalyzeRequiresBuiltTopologyInBothOverloads()
+        {
+            var mesh = CreateMesh(3, new[] { 0, 1, 2 });
+
+            var componentError = Assert.Throws<InvalidOperationException>(
+                () => mesh.Analyze(out uint[] _));
+            var orientationError = Assert.Throws<InvalidOperationException>(
+                () => mesh.Analyze(out uint[] _, out bool[] _));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(componentError!.Message, Does.Contain("requires topology"));
+                Assert.That(orientationError!.Message, Does.Contain("requires topology"));
+            });
+        }
+
+        [Test]
+        public void AnalyzeReportsWindingReversalAndManifoldCopyAppliesIt()
+        {
+            var first = new[] { 0, 1, 2 };
+            var sameDirection = new[] { 1, 2, 3 };
+            var mesh = CreateMesh(4, first, sameDirection);
+            mesh.BuildTopology();
+            Assert.That(mesh.IsNonManifold, Is.True);
+
+            var unorientedCount = mesh.Analyze(out var unorientedComponents);
+            var orientedCount = mesh.Analyze(out var orientedComponents, out var reversed);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(unorientedCount, Is.EqualTo(2));
+                Assert.That(unorientedComponents, Is.EqualTo(new uint[] { 0, 1 }));
+                Assert.That(orientedCount, Is.EqualTo(1));
+                Assert.That(orientedComponents, Is.EqualTo(new uint[] { 0, 0 }));
+                Assert.That(reversed, Is.EqualTo(new[] { false, true }));
+            });
+
+            var sourceFaces = mesh.Faces.Select(f => f.VertexIndices.ToArray()).ToArray();
+            var manifold = mesh.ManifoldCopy();
+            var copiedFaces = manifold.Faces.Select(f => f.VertexIndices.ToArray()).ToArray();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(mesh.Faces.Select(f => f.VertexIndices.ToArray()), Is.EqualTo(sourceFaces));
+                Assert.That(manifold.HasTopology, Is.False);
+                Assert.That(copiedFaces[0], Is.EqualTo(first));
+                Assert.That(copiedFaces[1], Is.EqualTo(sameDirection.Reverse().ToArray()));
+            });
+
+            manifold.BuildTopology();
+            Assert.Multiple(() =>
+            {
+                Assert.That(manifold.IsManifold, Is.True);
+                Assert.That(manifold.Analyze(out var components), Is.EqualTo(1));
+                Assert.That(components, Is.EqualTo(new uint[] { 0, 0 }));
+            });
+        }
+
+        [Test]
+        public void ConsistentWindingDoesNotRequestReversal()
+        {
+            var mesh = CreateMesh(4, new[] { 0, 1, 2 }, new[] { 2, 1, 3 });
+            mesh.BuildTopology();
+
+            var componentCount = mesh.Analyze(out var components, out var reversed);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(componentCount, Is.EqualTo(1));
+                Assert.That(components, Is.EqualTo(new uint[] { 0, 0 }));
+                Assert.That(reversed, Is.EqualTo(new[] { false, false }));
+            });
+        }
+
+        [Test]
+        public void ConnectedEdgesAtReturnsOtherEndpointEdgesExactlyOnce()
+        {
+            const int valence = 8;
+            var mesh = new PolyMesh();
+            var center = mesh.AddVertex(V3d.Zero);
+            for (var i = 0; i < valence; i++)
+            {
+                var angle = Constant.PiTimesTwo * i / valence;
+                mesh.AddVertex(new V3d(Math.Cos(angle), Math.Sin(angle), 0));
+            }
+            var unrelated = mesh.AddVertex(new V3d(10, 10, 0));
+            for (var i = 0; i < valence; i++)
+                mesh.AddFace(center, 1 + i, 1 + (i + 1) % valence);
+            mesh.BuildTopology();
+
+            var edge = mesh.GetEdge(center, 1);
+            Assert.That(edge.IsValid, Is.True);
+
+            AssertEndpointNeighborhood(edge, center, valence - 1);
+            AssertEndpointNeighborhood(edge, 1, 2);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(edge.GetConnectedEdgesAt(unrelated), Is.Empty);
+                Assert.That(edge.GetConnectedEdgesAt(mesh.GetVertex(unrelated)), Is.Empty);
+
+                var otherMesh = CreateMesh(3, new[] { 0, 1, 2 });
+                otherMesh.BuildTopology();
+                Assert.That(edge.GetConnectedEdgesAt(otherMesh.GetVertex(center)), Is.Empty);
+            });
+        }
+
+        private static void AssertEndpointNeighborhood(PolyMesh.Edge edge, int vertexIndex, int expectedCount)
+        {
+            var expected = edge.Mesh.GetVertex(vertexIndex).Edges
+                .Where(e => e.Index != edge.Index)
+                .Select(e => e.Index)
+                .ToArray();
+            var byIndex = edge.GetConnectedEdgesAt(vertexIndex).Select(e => e.Index).ToArray();
+            var byVertex = edge.GetConnectedEdgesAt(edge.Mesh.GetVertex(vertexIndex)).Select(e => e.Index).ToArray();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(byIndex, Is.EqualTo(expected));
+                Assert.That(byVertex, Is.EqualTo(expected));
+                Assert.That(byIndex, Has.Length.EqualTo(expectedCount));
+                Assert.That(byIndex.Distinct().Count(), Is.EqualTo(byIndex.Length));
+                Assert.That(byIndex, Does.Not.Contain(edge.Index));
+                Assert.That(byIndex.All(i => edge.Mesh.GetEdge(i).IsConnectedToVertex(vertexIndex)), Is.True);
+            });
+        }
+    }
+}

--- a/src/Aardvark.Geometry.PolyMesh/PolyMesh.cs
+++ b/src/Aardvark.Geometry.PolyMesh/PolyMesh.cs
@@ -1090,14 +1090,10 @@ namespace Aardvark.Geometry
         }
 
         /// <summary>
-        /// Returns a (hopeflully) manifold copy of the mesh, by using non-
-        /// manifold edge connections to combine faces with inconsistent
-        /// vertex order. If the vertex order is the only problem preventing
-        /// the mesh from being manifold, the returned mesh is indeed
-        /// manifold. If you need more control consider 'Analyze'
-        /// and 'FaceReversedCopy'. Note, that topology
-        /// information is not copied or built, since the actual euler
-        /// characteristic of the mesh is not known.
+        /// Returns a copy with faces reversed according to
+        /// <see cref="Analyze(out uint[], out bool[])"/>. Face order and component membership are
+        /// preserved. The result is manifold when inconsistent face winding was the only obstruction.
+        /// Valid source topology is required; result topology is intentionally not copied or rebuilt.
         /// </summary>
         public PolyMesh ManifoldCopy()
         {
@@ -1241,12 +1237,14 @@ namespace Aardvark.Geometry
         }
 
         /// <summary>
-        /// Analyze the mesh with respect to components, without taking non-
-        /// manifold edges into account. Returns the number of components,
-        /// and the component index index of each face.
+        /// Analyzes edge-connected face components without traversing non-manifold edge links.
+        /// Returns the component count and, for each face, its zero-based component index.
+        /// Valid topology must have been built before calling this method.
         /// </summary>
+        /// <exception cref="InvalidOperationException">The mesh has no built topology.</exception>
         public uint Analyze(out uint[] faceComponentIndexArray)
         {
+            if (!HasTopology) throw new InvalidOperationException("Analyze requires topology.");
             var cia = new uint[m_faceCount].Set(uint.MaxValue);
             var cc = Analyze(cia, null);
             faceComponentIndexArray = cia;
@@ -1254,17 +1252,16 @@ namespace Aardvark.Geometry
         }
 
         /// <summary>
-        /// Analyze the mesh with respect to components, taking non-manifold
-        /// edges into account. Returns the number of components, the
-        /// component index index of each face, and a bool for each face
-        /// if it is flipped with respect to the first face of the component
-        /// (first face being the one with the lowest face index).
-        /// NOTE: Mesh requires valid topology.
+        /// Analyzes edge-connected face components, following non-manifold edge links as needed.
+        /// Returns the component count, each face's zero-based component index, and whether each
+        /// face must be reversed relative to the lowest-indexed face in its component. Valid topology
+        /// must have been built before calling this method.
         /// </summary>
+        /// <exception cref="InvalidOperationException">The mesh has no built topology.</exception>
         public uint Analyze(out uint[] faceComponentIndexArray,
                 out bool[] faceReversedArray)
         {
-            if (!HasTopology) throw new Exception("Analyze requires topology");
+            if (!HasTopology) throw new InvalidOperationException("Analyze requires topology.");
             var fcia = new uint[m_faceCount].Set(uint.MaxValue);
             var ffa = new bool[m_faceCount];
             var cc = Analyze(fcia, ffa);
@@ -1293,7 +1290,7 @@ namespace Aardvark.Geometry
                 if (fcia[fi] < uint.MaxValue) continue;
                 if (ffa != null) ffa[fi] = false;
                 fcia[fi] = cc;
-                var fec = EdgeCountOfFace(0);
+                var fec = EdgeCountOfFace(fi);
                 for (int fs = 0; fs < fec; fs++)
                     queue.Enqueue(new EdgeRefReversion(EdgeRefOfFace(fi, fs), false));
                 while (queue.Count > 0)
@@ -2204,8 +2201,9 @@ namespace Aardvark.Geometry
         {
             var fia = m_firstIndexArray;
             int fvi = fia[faceIndex], fvc = fia[faceIndex + 1] - fvi;
-            if (faceSide < 0) faceSide = faceSide % fvc + fvc;
-            return m_faceEdgeRefArray[fvi + (faceSide + faceSide) % fvc];
+            faceSide %= fvc;
+            if (faceSide < 0) faceSide += fvc;
+            return m_faceEdgeRefArray[fvi + faceSide];
         }
 
         internal FaceRef TurnedFaceRef(FaceRef faceRef, int turnCount)
@@ -3482,21 +3480,22 @@ namespace Aardvark.Geometry
                 => FaceIndex == faceIndex || OppositeFaceIndex == faceIndex;
 
             /// <summary>
-            /// Returns all connected edges of this vertex.
-            /// Note: The vertex must be connected to this edge.
+            /// Returns the other edges incident to the supplied vertex when it is an endpoint of
+            /// this edge. Returns an empty sequence for an unrelated vertex. Valid topology is required.
             /// </summary>
             public IEnumerable<Edge> GetConnectedEdgesAt(int vertexIndex)
                 => GetConnectedEdgesAt(new Vertex(Mesh, vertexIndex));
 
             /// <summary>
-            /// Returns all connected edges of this vertex.
+            /// Returns the other edges incident to the supplied vertex when it belongs to this mesh
+            /// and is an endpoint of this edge. Returns an empty sequence otherwise. Valid topology is required.
             /// </summary>
             public IEnumerable<Edge> GetConnectedEdgesAt(Vertex vertex)
             {
-                if (IsConnectedToVertex(vertex))
+                if (vertex.Mesh != Mesh || !IsConnectedToVertex(vertex.Index))
                     return Enumerable.Empty<Edge>();
-                var ei = Index;
-                return vertex.Edges.Where(e => e.Index != ei);
+                var edgeIndex = Index;
+                return vertex.Edges.Where(edge => edge.Index != edgeIndex);
             }
 
             /// <summary>


### PR DESCRIPTION
## Summary
- map each requested face side to its actual half-edge with standard modulo wrapping
- seed each disconnected `Analyze` component using that face’s edge count instead of face zero’s count
- make both `Analyze` overloads consistently require built topology and preserve deterministic component/reversal output
- make both `Edge.GetConnectedEdgesAt` overloads return the other incident edges only for endpoints belonging to the same mesh, and empty results for unrelated vertices
- preserve face order and winding repair through `ManifoldCopy`
- document topology preconditions, edge-connected components, reversal semantics, and endpoint neighborhoods

## Regression coverage
Thirty-four focused cases cover shared edges on every side of four- and five-sided faces, all rotated starts for connected quad/pentagon pairs, mixed face sizes, disconnected components with different seed valence, both `Analyze` overloads, missing-topology failures, consistent and inconsistent winding, reversal arrays, `ManifoldCopy`, both endpoint-query overloads, unrelated/cross-mesh vertices, and duplicate-free output.

## Performance
Warmed Release medians used large built topologies and equivalent configurations.

| Path | Before | After | Allocation |
| --- | ---: | ---: | ---: |
| 32,768-triangle analysis | 0.512 ms | 0.500 ms (-2.3%) | 139,488 B unchanged |
| 20,000-face mixed-valence analysis | 0.411 ms | 0.408 ms (-0.6%) | 80,208 B unchanged |
| 64-valence endpoint neighborhood | 0.493 µs | 0.487 µs (-1.3%) | 256 B unchanged |
| unrelated-vertex query | 0.084 µs | 0.026 µs (-68.9%) | 256 → 24 B |

The old endpoint method returned no elements, so its corrected path is compared with the existing equivalent `FromVertexEdges`/`ToVertexEdges` neighborhood traversal. Mixed-valence output intentionally changes from split to one connected component.

## Validation
- 34 focused topology tests passed
- 476 complete-suite tests passed with 2 existing skips
- complete Release solution build passed with warnings treated as errors

Fixes #83.