### PR TITLE
Fix BSP optional-attribute sorting and traversal allocations

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,5 @@
+- [BspTree] Fix optional-attribute sorting and reduce traversal allocations (#85).
+
 ### 5.6.3
 - Updated SharpCompress to 0.48.1 to address CVE-2026-44788
 

--- a/ai/GEOMETRY.md
+++ b/ai/GEOMETRY.md
@@ -25,21 +25,38 @@ var builder = new BspTreeBuilder(indices, positions, absoluteEpsilon: 1e-6);
 var bspTree = builder.BspTree;
 
 // Sort indices back-to-front for transparency rendering
-var sortedIndices = new int[indices.Length];
-var countdown = bspTree.SortVertexIndexArray(
+var sortedIndices = new int[builder.TriangleCountMul3]; // Includes split fragments
+using var countdown = bspTree.SortVertexIndexArray(
     BspTree.Order.BackToFront,
     eyePosition,
     sortedIndices,
     parallel: true
 );
 countdown.Wait(); // Block until sorting completes
+
+// The paired API works on the same tree, even when no attributes were supplied.
+var sortedAttributes = new int[builder.TriangleCountMul3 / 3];
+using var paired = bspTree.SortVertexAndAttributeIndexArrays(
+    BspTree.Order.BackToFront, eyePosition, sortedIndices, sortedAttributes,
+    parallel: false
+);
+// Serial completion is already signalled; sortedAttributes contains zeros here.
 ```
+
+### Sorting Contract
+
+- Both output APIs work on finalized trees built with or without `triangleAttributeIndexArray`, in either order and execution mode. For the same viewpoint/order their vertex outputs agree.
+- Attribute IDs remain aligned with triangles, including all split fragments. When the tree has no attributes, the paired API overwrites each requested triangle's attribute with zero. Passing a null attribute output omits attribute writes.
+- Allocate vertex output using `builder.TriangleCountMul3` and attribute output using `builder.TriangleCountMul3 / 3`, not the original input count. Entries beyond those counts are untouched. Keep `builder.PositionArray` to resolve newly generated split vertices.
+- Finalize once via `builder.BspTree`; do not sort the builder itself. Finalized trees are not mutated or repacked during sorting and support repeated/concurrent calls with separate output buffers.
+- Wait for the returned `CountdownEvent` before reading or reusing outputs, then dispose it. Serial calls return an already-signalled event; parallel work uses the default task scheduler.
+- Serialized layouts remain unchanged: node indices/counts use vertex-index units without attributes and triangle units with attributes. Sorting selects those units from the stored attribute presence, not the output API.
 
 ### Gotchas
 
-- **BspTreeBuilder modifies input arrays** – Always pass copies of index/position arrays.
+- **BspTreeBuilder modifies input arrays** – Always pass copies of index/position arrays and any attribute-index array.
 - **Epsilon controls splitting** – Too small creates deep trees; too large loses precision.
-- **Parallel sorting returns async event** – `SortVertexIndexArray` returns `CountdownEvent`; call `.Wait()` to block.
+- **Parallel sorting returns async event** – Both sorting APIs return `CountdownEvent`; call `.Wait()` to block, then dispose it.
 - **Tree construction uses shuffle** – Triangles are inserted in shuffled order to reduce tree depth.
 - **Split triangles are duplicated** – Triangles straddling planes are cloned into fragments; final triangle count may exceed original.
 

--- a/src/Aardvark.Algodat.Tests/Aardvark.Algodat.Tests.csproj
+++ b/src/Aardvark.Algodat.Tests/Aardvark.Algodat.Tests.csproj
@@ -23,6 +23,7 @@
     <ProjectReference Include="..\Aardvark.Data.Points.Base\Aardvark.Data.Points.Base.csproj" />
     <ProjectReference Include="..\Aardvark.Data.Points.LasZip\Aardvark.Data.Points.LasZip.csproj" />
     <ProjectReference Include="..\Aardvark.Data.Points.Ply\Aardvark.Data.Points.Ply.csproj" />
+    <ProjectReference Include="..\Aardvark.Geometry.BspTree\Aardvark.Geometry.BspTree.csproj" />
     <ProjectReference Include="..\Aardvark.Geometry.Clustering\Aardvark.Geometry.Clustering.csproj" />
     <ProjectReference Include="..\Aardvark.Geometry.PointSet\Aardvark.Geometry.PointSet.csproj" />
     <ProjectReference Include="..\Aardvark.Geometry.PolyMesh\Aardvark.Geometry.PolyMesh.csproj" />

--- a/src/Aardvark.Algodat.Tests/BspTreeTests.cs
+++ b/src/Aardvark.Algodat.Tests/BspTreeTests.cs
@@ -1,0 +1,289 @@
+using Aardvark.Base;
+using Aardvark.Base.Coder;
+using NUnit.Framework;
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using TypeInfo = Aardvark.Base.Coder.TypeInfo;
+
+namespace Aardvark.Geometry.Tests
+{
+    [TestFixture]
+    public class BspTreeTests
+    {
+        private const int Sentinel = int.MinValue;
+        private static readonly TimeSpan CompletionTimeout = TimeSpan.FromSeconds(10);
+
+        // SplitTriangles serialized before this repair (7c9ea62). Keep both historical
+        // node/index units covered, not merely round trips written by the new code.
+        private const string VertexLayout =
+            "CEFhcmR2YXJrBAAAAB4BAAAAAAAAB0JzcFRyZWUAAAAACgEAAAAAAAABYgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADwPwEAAAAAAAAABgAAAAFiAAAAAAAA4D8AAAAAAAAAAAAAAAAAAAAAVVVVVVVV5b9VVVVVVVXlv1VVVVVVVdU/AgAAAAYAAAAJAAAAAAAAAAFuAAAAAAFuAwAAAAFiAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPC/VVVVVVVV5b9VVVVVVVXlv1VVVVVVVdU/AQAAAAMAAAAAAAAAAW4AAAAAAW4MAAAAAAAAAAEAAAACAAAAAwAAAAYAAAAHAAAABgAAAAQAAAAFAAAABgAAAAUAAAAHAAAA/////w==";
+        private const string AttributeLayout =
+            "CEFhcmR2YXJrBAAAAC4BAAAAAAAAB0JzcFRyZWUAAAAAGgEAAAAAAAABYgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADwPwEAAAAAAAAAAgAAAAFiAAAAAAAA4D8AAAAAAAAAAAAAAAAAAAAAVVVVVVVV5b9VVVVVVVXlv1VVVVVVVdU/AgAAAAIAAAADAAAAAAAAAAFuAAAAAAFuAQAAAAFiAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPC/VVVVVVVV5b9VVVVVVVXlv1VVVVVVVdU/AQAAAAEAAAAAAAAAAW4AAAAAAW4MAAAAAAAAAAEAAAACAAAAAwAAAAYAAAAHAAAABgAAAAQAAAAFAAAABgAAAAUAAAAHAAAABAAAAAoAAAAUAAAAFAAAABQAAAA=";
+
+        // Pin the root alias locally: assembly discovery/global coder registration
+        // differs between isolated tests, full-suite runs and coverage instrumentation.
+        private static readonly TypeInfo[] TreeTypeInfo = { new TypeInfo("BspTree", typeof(BspTree)) };
+
+        private static byte[] EncodeTree(BspTree tree)
+        {
+            using var stream = new MemoryStream();
+            using (var coder = new BinaryWritingCoder(stream))
+            {
+                coder.Add(TreeTypeInfo);
+                coder.CodeT(ref tree);
+            }
+            return stream.ToArray();
+        }
+
+        private static BspTree DecodeTree(byte[] encoded)
+        {
+            using var stream = new MemoryStream(encoded);
+            using var coder = new BinaryReadingCoder(stream);
+            coder.Add(TreeTypeInfo);
+            BspTree tree = null;
+            coder.CodeT(ref tree);
+            return tree;
+        }
+
+        private static BspTreeBuilder ParallelTriangles(bool attributes, params double[] heights)
+        {
+            var positions = heights.SelectMany(z => new[]
+            {
+                new V3d(0, 0, z), new V3d(1, 0, z), new V3d(0, 1, z)
+            }).ToArray();
+            var indices = Enumerable.Range(0, positions.Length).ToArray();
+            return attributes
+                ? new BspTreeBuilder(indices, positions, 1e-9,
+                    Enumerable.Range(1, heights.Length).Select(i => i * 10).ToArray())
+                : new BspTreeBuilder(indices, positions, 1e-9);
+        }
+
+        private static BspTreeBuilder SplitTriangles(bool attributes)
+        {
+            return new BspTreeBuilder(new[] { 0, 1, 2, 3, 4, 5 }, new[]
+            {
+                new V3d(0, 0, 0), new V3d(1, 0, 0), new V3d(0, 1, 0),
+                new V3d(0, 0, -1), new V3d(1, 0, 1), new V3d(0, 1, 1)
+            }, 1e-9, attributes ? new[] { 10, 20 } : null);
+        }
+
+        private static bool Ascending(BspTree.Order order, double eyeZ)
+            => (order == BspTree.Order.BackToFront) == (eyeZ >= 0);
+
+        private static void WaitForCompletion(CountdownEvent finished, bool parallel)
+        {
+            // Never hang the test runner when a worker fails to signal completion.
+            if (!parallel) Assert.That(finished.IsSet, Is.True, "Serial sorts must finish before returning.");
+            Assert.That(finished.Wait(CompletionTimeout), Is.True, "BSP sort did not complete.");
+            Assert.That(finished.CurrentCount, Is.Zero);
+        }
+
+        private static void AssertSort(BspTree tree, int vertexCount, bool paired,
+            BspTree.Order order, double eyeZ, bool parallel, int[] expectedVertices, int[] expectedAttributes)
+        {
+            // Oversized, poisoned buffers also detect unwritten slots and writes past the final count.
+            var vertices = Enumerable.Repeat(Sentinel, vertexCount + 3).ToArray();
+            var attributes = Enumerable.Repeat(Sentinel, vertexCount / 3 + 2).ToArray();
+            var eye = new V3d(0.25, 0.25, eyeZ);
+            using var finished = paired
+                ? tree.SortVertexAndAttributeIndexArrays(order, eye, vertices, attributes, parallel)
+                : tree.SortVertexIndexArray(order, eye, vertices, parallel);
+            WaitForCompletion(finished, parallel);
+            Assert.That(vertices.Take(vertexCount), Is.EqualTo(expectedVertices));
+            Assert.That(vertices.Skip(vertexCount), Is.All.EqualTo(Sentinel));
+            Assert.That(attributes.Take(vertexCount / 3), paired
+                ? Is.EqualTo(expectedAttributes)
+                : Is.All.EqualTo(Sentinel));
+            Assert.That(attributes.Skip(vertexCount / 3), Is.All.EqualTo(Sentinel));
+        }
+
+        [Test]
+        public void BuilderReportsAttributePresence([Values] bool attributes)
+        {
+            var builder = ParallelTriangles(attributes, 0, 1);
+            Assert.That(builder.HasAttributeArray, Is.EqualTo(attributes));
+            Assert.That(builder.TriangleCountMul3, Is.EqualTo(6));
+            _ = builder.BspTree;
+            Assert.That(builder.HasAttributeArray, Is.EqualTo(attributes));
+        }
+
+        [Test, Combinatorial]
+        public void TwoParallelTrianglesSortAcrossLayouts(
+            [Values] bool attributes, [Values] bool paired, [Values] BspTree.Order order,
+            [Values] bool parallel, [Values(-2.0, 2.0, 0.0)] double eyeZ)
+        {
+            // Regression: indices [0,1,2,3,4,5], optional IDs [10,20], at z=0 and z=1.
+            var builder = ParallelTriangles(attributes, 0, 1);
+            var tree = builder.BspTree;
+            var ascending = Ascending(order, eyeZ);
+            AssertSort(tree, builder.TriangleCountMul3, paired, order, eyeZ, parallel,
+                ascending ? new[] { 0, 1, 2, 3, 4, 5 } : new[] { 3, 4, 5, 0, 1, 2 },
+                !attributes ? new[] { 0, 0 } : ascending ? new[] { 10, 20 } : new[] { 20, 10 });
+        }
+
+        [Test, Combinatorial]
+        public void CoplanarTrianglesAndBothChildSubtreesSortAcrossLayouts(
+            [Values] bool attributes, [Values] bool paired, [Values] BspTree.Order order,
+            [Values] bool parallel, [Values(-3.0, 3.0)] double eyeZ)
+        {
+            // The root contains triangles 0 and 1; both children have descendants.
+            var builder = ParallelTriangles(attributes, 0, 0, -1, 1, -2, 2);
+            var tree = builder.BspTree;
+            var triangleOrder = Ascending(order, eyeZ)
+                ? new[] { 4, 2, 0, 1, 3, 5 }
+                : new[] { 5, 3, 0, 1, 2, 4 };
+            AssertSort(tree, builder.TriangleCountMul3, paired, order, eyeZ, parallel,
+                triangleOrder.SelectMany(i => new[] { 3 * i, 3 * i + 1, 3 * i + 2 }).ToArray(),
+                triangleOrder.Select(i => attributes ? (i + 1) * 10 : 0).ToArray());
+        }
+
+        [Test, Combinatorial]
+        public void SplitFragmentsKeepTheirAttributesAcrossLayouts(
+            [Values] bool attributes, [Values] bool paired, [Values] BspTree.Order order,
+            [Values] bool parallel, [Values(-2.0, 2.0)] double eyeZ)
+        {
+            var builder = SplitTriangles(attributes);
+            Assert.That(builder.TriangleCountMul3, Is.EqualTo(12));
+            Assert.That(builder.VertexCount, Is.EqualTo(8));
+            Assert.That(builder.PositionArray[6], Is.EqualTo(new V3d(0.5, 0, 0)));
+            Assert.That(builder.PositionArray[7], Is.EqualTo(new V3d(0, 0.5, 0)));
+            var tree = builder.BspTree;
+            var ascending = Ascending(order, eyeZ);
+            AssertSort(tree, builder.TriangleCountMul3, paired, order, eyeZ, parallel,
+                ascending
+                    ? new[] { 3, 6, 7, 0, 1, 2, 6, 4, 5, 6, 5, 7 }
+                    : new[] { 6, 4, 5, 6, 5, 7, 0, 1, 2, 3, 6, 7 },
+                !attributes ? new[] { 0, 0, 0, 0 }
+                    : ascending ? new[] { 20, 10, 20, 20 } : new[] { 20, 20, 10, 20 });
+        }
+
+        [Test, Combinatorial]
+        public void SerializationPreservesBothPackedLayouts(
+            [Values] bool attributes, [Values] bool paired, [Values] BspTree.Order order,
+            [Values] bool parallel, [Values(-2.0, 2.0)] double eyeZ)
+        {
+            var builder = SplitTriangles(attributes);
+            var tree = builder.BspTree;
+            var encoded = Convert.FromBase64String(attributes ? AttributeLayout : VertexLayout);
+            Assert.That(EncodeTree(tree), Is.EqualTo(encoded), "The serialized representation must remain unchanged.");
+            var decoded = DecodeTree(encoded);
+            Assert.That(EncodeTree(decoded), Is.EqualTo(encoded));
+            var ascending = Ascending(order, eyeZ);
+            AssertSort(decoded, builder.TriangleCountMul3, paired, order, eyeZ, parallel,
+                ascending
+                    ? new[] { 3, 6, 7, 0, 1, 2, 6, 4, 5, 6, 5, 7 }
+                    : new[] { 6, 4, 5, 6, 5, 7, 0, 1, 2, 3, 6, 7 },
+                !attributes ? new[] { 0, 0, 0, 0 }
+                    : ascending ? new[] { 20, 10, 20, 20 } : new[] { 20, 20, 10, 20 });
+            Assert.That(EncodeTree(decoded), Is.EqualTo(encoded), "Sorting must not mutate the packed tree.");
+        }
+
+        [Test]
+        public void RepeatedAndConcurrentSortsAgreeBetweenApis([Values] bool attributes)
+        {
+            var builder = SplitTriangles(attributes);
+            var tree = builder.BspTree;
+            var encoded = tree.Encode();
+            for (var repeat = 0; repeat < 3; repeat++)
+            {
+                var jobs = Enumerable.Range(0, 32).Select(i => Task.Run(() =>
+                {
+                    var order = (i & 1) == 0 ? BspTree.Order.BackToFront : BspTree.Order.FrontToBack;
+                    var eye = new V3d(0.25, 0.25, (i & 2) == 0 ? 2 : -2);
+                    var parallel = (i & 4) == 0;
+                    // Exactly-sized buffers, independent for every outstanding call.
+                    var vertices = Enumerable.Repeat(Sentinel, builder.TriangleCountMul3).ToArray();
+                    var pairedVertices = Enumerable.Repeat(Sentinel, vertices.Length).ToArray();
+                    var ids = Enumerable.Repeat(Sentinel, vertices.Length / 3).ToArray();
+                    using var vertexFinished = tree.SortVertexIndexArray(order, eye, vertices, parallel);
+                    using var pairedFinished = tree.SortVertexAndAttributeIndexArrays(order, eye, pairedVertices, ids, parallel);
+                    WaitForCompletion(vertexFinished, parallel);
+                    WaitForCompletion(pairedFinished, parallel);
+                    Assert.That(vertices, Is.EqualTo(pairedVertices));
+                    Assert.That(vertices, Does.Not.Contain(Sentinel));
+                    for (var j = 0; j < ids.Length; j++)
+                        Assert.That(ids[j], Is.EqualTo(!attributes ? 0 : vertices[j * 3] == 0 ? 10 : 20));
+                })).ToArray();
+                Assert.That(Task.WaitAll(jobs, TimeSpan.FromSeconds(30)), Is.True, "Concurrent sorts did not complete.");
+            }
+            Assert.That(tree.Encode(), Is.EqualTo(encoded));
+        }
+
+        [Test, Combinatorial]
+        public void NullAttributeOutputAgreesWithVertexOnlyApi(
+            [Values] bool attributes, [Values] BspTree.Order order, [Values] bool parallel)
+        {
+            var builder = SplitTriangles(attributes);
+            var tree = builder.BspTree;
+            var vertices = new int[builder.TriangleCountMul3];
+            var pairedVertices = new int[vertices.Length];
+            using var vertexFinished = tree.SortVertexIndexArray(order, new V3d(0, 0, 2), vertices, parallel);
+            using var pairedFinished = tree.SortVertexAndAttributeIndexArrays(order, new V3d(0, 0, 2), pairedVertices, null, parallel);
+            WaitForCompletion(vertexFinished, parallel);
+            WaitForCompletion(pairedFinished, parallel);
+            Assert.That(pairedVertices, Is.EqualTo(vertices));
+        }
+
+        [Test, Combinatorial]
+        public void ParallelSortDoesNotDependOnCallingTaskScheduler(
+            [Values] bool attributes, [Values] bool paired, [Values] BspTree.Order order)
+        {
+            var builder = ParallelTriangles(attributes, 0, 1);
+            var tree = builder.BspTree;
+            var scheduler = new ConcurrentExclusiveSchedulerPair(TaskScheduler.Default, maxConcurrencyLevel: 1);
+            try
+            {
+                // Waiting inside an exclusive task must not prevent root/child workers
+                // from running. Parallel sorts use the default scheduler instead.
+                var job = Task.Factory.StartNew(() =>
+                {
+                    var ascending = order == BspTree.Order.BackToFront;
+                    AssertSort(tree, builder.TriangleCountMul3, paired, order, 2, true,
+                        ascending ? new[] { 0, 1, 2, 3, 4, 5 } : new[] { 3, 4, 5, 0, 1, 2 },
+                        !attributes ? new[] { 0, 0 } : ascending ? new[] { 10, 20 } : new[] { 20, 10 });
+                }, CancellationToken.None, TaskCreationOptions.None, scheduler.ExclusiveScheduler);
+                Assert.That(job.Wait(TimeSpan.FromSeconds(30)), Is.True);
+            }
+            finally
+            {
+                scheduler.Complete();
+                Assert.That(scheduler.Completion.Wait(TimeSpan.FromSeconds(30)), Is.True);
+            }
+        }
+
+        [Test, Combinatorial]
+        public void LargeSubtreesCompleteAcrossTaskChunkBoundary(
+            [Values] bool attributes, [Values] bool paired, [Values] BspTree.Order order,
+            [Values] bool parallel)
+        {
+            // Both layouts exceed the 32768-unit task threshold and have smaller
+            // descendants that must be scheduled. Coplanar groups keep construction shallow.
+            const int count = 70000;
+            var levels = new[] { -4.0, 4.0, -2.0, 2.0, -3.0, 3.0, -1.0, 1.0 };
+            var heights = Enumerable.Range(0, count).Select(i => i == 0 ? 0.0 : levels[i % levels.Length]).ToArray();
+            var builder = ParallelTriangles(attributes, heights);
+            var tree = builder.BspTree;
+            var vertices = Enumerable.Repeat(Sentinel, builder.TriangleCountMul3).ToArray();
+            var ids = Enumerable.Repeat(Sentinel, count).ToArray();
+            using var finished = paired
+                ? tree.SortVertexAndAttributeIndexArrays(order, new V3d(0, 0, 5), vertices, ids, parallel)
+                : tree.SortVertexIndexArray(order, new V3d(0, 0, 5), vertices, parallel);
+            WaitForCompletion(finished, parallel);
+            Assert.That(vertices.OrderBy(i => i), Is.EqualTo(Enumerable.Range(0, 3 * count)));
+            double previous = order == BspTree.Order.BackToFront ? double.NegativeInfinity : double.PositiveInfinity;
+            for (var i = 0; i < count; i++)
+            {
+                var triangle = vertices[3 * i] / 3;
+                Assert.That(vertices[3 * i + 1], Is.EqualTo(3 * triangle + 1));
+                Assert.That(vertices[3 * i + 2], Is.EqualTo(3 * triangle + 2));
+                if (paired) Assert.That(ids[i], Is.EqualTo(attributes ? (triangle + 1) * 10 : 0));
+                var z = heights[triangle];
+                Assert.That(order == BspTree.Order.BackToFront ? z >= previous : z <= previous, Is.True);
+                previous = z;
+            }
+        }
+    }
+}

--- a/src/Aardvark.Geometry.BspTree/BspTree.cs
+++ b/src/Aardvark.Geometry.BspTree/BspTree.cs
@@ -39,7 +39,9 @@ namespace Aardvark.Geometry
     /// <summary>
     /// A BspTree holds a triangle vertex index array and a tree of BspNodes
     /// that allow the sorting of the triangle vertex index array based on
-    /// an eye point.
+    /// an eye point. On a finalized tree, both sorting APIs support trees
+    /// built with or without triangle attribute indices, without modifying
+    /// the tree. Concurrent sorts must use separate output buffers.
     /// </summary>
     [RegisterTypeInfo]
     public class BspTree : IFieldCodeable
@@ -86,24 +88,35 @@ namespace Aardvark.Geometry
         #region Sorting An Array
 
         /// <summary>
-        /// Sorts index array (optionally single threaded)
-        /// Both variants return a CountdownEvent. For
-        /// sequential execution (parallel = false), the
-        /// returned event initially is signalled.
+        /// Sorts triangle vertex indices on a finalized tree, whether or not
+        /// it contains triangle attribute indices. The vertex output agrees
+        /// with <see cref="SortVertexAndAttributeIndexArrays"/>.
         /// </summary>
+        /// <param name="order">The requested triangle order.</param>
+        /// <param name="eye">The viewpoint used for sorting.</param>
+        /// <param name="vertexIndexArray">Output with at least
+        /// <see cref="BspTreeBuilder.TriangleCountMul3"/> entries, using the
+        /// finalized count (including split fragments). Extra entries are untouched.</param>
+        /// <param name="parallel">Whether to sort asynchronously using worker tasks.</param>
+        /// <returns>A completion event that must be awaited before reading the output
+        /// and disposed afterward. For serial execution it is already signalled.</returns>
         public CountdownEvent SortVertexIndexArray(
             Order order, V3d eye, int[] vertexIndexArray, bool parallel = true)
         {
-            var target = new TargetArray()
-            {
-                Via = vertexIndexArray,
-                Finished = new CountdownEvent(1)
-            };
+            // Packing with attributes stores triangle ordinals; without attributes
+            // it stores vertex-index offsets. The output API does not determine this.
+            if (m_triangleAttributeIndexArray != null)
+                return SortVertexAndAttributeIndexArrays(order, eye, vertexIndexArray, null, parallel);
 
-            void runParallel(Action a) => Task.Factory.StartNew(a);
-            void runSequential(Action a) => a();
+            return SortVertexIndexArray(order, eye, new TargetArray(vertexIndexArray), parallel);
+        }
+
+        private CountdownEvent SortVertexIndexArray(
+            Order order, V3d eye, TargetArray target, bool parallel)
+        {
+            static void runParallel(Action a) => Task.Run(a);
+            static void runSequential(Action a) => a();
             Action<Action> runChild = parallel ? runParallel : runSequential;
-                        
 
             if (order == Order.BackToFront)
                 runChild(() =>
@@ -120,21 +133,35 @@ namespace Aardvark.Geometry
 
             if (!parallel) target.Finished.Wait();
 
-			return target.Finished;
+            return target.Finished;
         }
 
-		public CountdownEvent SortVertexAndAttributeIndexArrays(
+        /// <summary>
+        /// Sorts aligned triangle vertex and attribute indices on a finalized tree.
+        /// Either packed layout is supported. Supplied attribute IDs follow their
+        /// triangles, including split fragments; trees built without attributes
+        /// write zero for every output triangle.
+        /// </summary>
+        /// <param name="order">The requested triangle order.</param>
+        /// <param name="eye">The viewpoint used for sorting.</param>
+        /// <param name="vertexIndexArray">Output with at least
+        /// <see cref="BspTreeBuilder.TriangleCountMul3"/> entries.</param>
+        /// <param name="attributeIndexArray">Output with at least
+        /// <see cref="BspTreeBuilder.TriangleCountMul3"/> / 3 entries, or null to
+        /// omit attributes. Both output sizes use the finalized count, including
+        /// split fragments. Extra entries are untouched.</param>
+        /// <param name="parallel">Whether to sort asynchronously using worker tasks.</param>
+        /// <returns>A completion event that must be awaited before reading the output
+        /// and disposed afterward. For serial execution it is already signalled.</returns>
+        public CountdownEvent SortVertexAndAttributeIndexArrays(
             Order order, V3d eye, int[] vertexIndexArray, int[] attributeIndexArray, bool parallel = true)
         {
-            var target = new TargetArrays()
-            {
-                // Count = 0,
-                Via = vertexIndexArray,
-                Aia = attributeIndexArray,
-                Finished = new CountdownEvent(1)
-            };
+            var target = new TargetArrays(vertexIndexArray, attributeIndexArray);
 
-            static void runParallel(Action a) => Task.Factory.StartNew(a);
+            if (m_triangleAttributeIndexArray == null)
+                return SortVertexIndexArray(order, eye, target, parallel);
+
+            static void runParallel(Action a) => Task.Run(a);
             static void runSequential(Action a) => a();
             Action<Action> runChild = parallel ? runParallel : runSequential;
 
@@ -150,7 +177,7 @@ namespace Aardvark.Geometry
                     m_tree.SortFrontToBack(this, target, 0, eye, true, runChild);
                     target.Finished.Signal();
                 });
-			return target.Finished;
+            return target.Finished;
         }
 
         #endregion
@@ -193,12 +220,13 @@ namespace Aardvark.Geometry
 
     /// <summary>
     /// A BspTreeBuilder is only used while building a BspTree, after
-    /// it has been built, it can be retrived via the property 
+    /// it has been built, it can be retrieved via the property
     /// <see cref="BspTree"/>. Afterward the BspTreeBuilder is not needed
     /// anymore.
     /// </summary>
     public class BspTreeBuilder : BspTree
     {
+        /// <summary>Whether triangle attribute indices were supplied to the builder.</summary>
         public readonly bool HasAttributeArray;
 
         private readonly int m_originalVertexCount;
@@ -236,6 +264,7 @@ namespace Aardvark.Geometry
                               int[] triangleAttributeIndexArray)
             : base(null, triangleVertexIndexArray, triangleAttributeIndexArray)
         {
+            HasAttributeArray = triangleAttributeIndexArray != null;
             m_weightsArray = [];
             m_positionArray = vertexPositionArray;
 
@@ -261,6 +290,10 @@ namespace Aardvark.Geometry
 
         #region Properties
 
+        /// <summary>
+        /// Finalized triangle count multiplied by three, including split fragments.
+        /// Use this for vertex-index output sizing and divide by three for attribute output.
+        /// </summary>
         public int TriangleCountMul3 { get; private set; }
 
         public int VertexCount { get; private set; }
@@ -286,7 +319,9 @@ namespace Aardvark.Geometry
 
         /// <summary>
         /// This property should only be read once to obtain a finalized
-        /// BspTree.
+        /// BspTree. Sorting supports both output APIs regardless of whether
+        /// attributes were supplied. Keep <see cref="TriangleCountMul3"/> for
+        /// output sizing and <see cref="PositionArray"/> for split vertices.
         /// </summary>
         public BspTree BspTree
         {
@@ -411,19 +446,18 @@ namespace Aardvark.Geometry
     }
 
     /// <summary>
-    /// Volatile array for parallel bsp sorting.
+    /// Per-sort buffers, published to worker tasks with immutable references.
+    /// Each node writes a disjoint range; completion synchronizes output reads.
     /// </summary>
-    internal class TargetArray
+    internal class TargetArray(int[] via)
     {
-        public CountdownEvent Finished;
-        public volatile int[] Via;
+        public readonly CountdownEvent Finished = new(1);
+        public readonly int[] Via = via;
     }
 
-    internal class TargetArrays
+    internal class TargetArrays(int[] via, int[] aia) : TargetArray(via)
     {
-        public CountdownEvent Finished;
-        public volatile int[] Via;
-        public volatile int[] Aia;
+        public readonly int[] Aia = aia;
     }
 
     internal class BspNode : IFieldCodeable
@@ -670,11 +704,73 @@ namespace Aardvark.Geometry
 
         private const int c_taskChunkSize = 32768;
 
-        /// <summary>
-        /// Note, that the parallel implementation of this method could be
-        /// optimized, by providing separate node types for parallel and non
-        /// parallel execution.
-        /// </summary>
+        // Keep task closures out of recursive traversal methods: only scheduled
+        // subtrees need a closure, not every visited node. Index units still come
+        // from the stored layout, independently of the requested output buffers.
+        private void ScheduleSort(BspTree tree, TargetArray target, int index, V3d eye,
+            bool backToFront, Action<Action> runChild)
+        {
+            target.Finished.AddCount(1);
+            runChild(() =>
+            {
+                if (tree.m_triangleAttributeIndexArray == null)
+                {
+                    if (backToFront) SortBackToFront(tree, target, index, eye, false, runChild);
+                    else SortFrontToBack(tree, target, index, eye, false, runChild);
+                }
+                else
+                {
+                    var arrays = (TargetArrays)target;
+                    if (backToFront) SortBackToFront(tree, arrays, index, eye, false, runChild);
+                    else SortFrontToBack(tree, arrays, index, eye, false, runChild);
+                }
+                target.Finished.Signal();
+            });
+        }
+
+        // The layout-specific copy loops share both sort orders and cache immutable
+        // buffer references. Node indices need not be assumed contiguous.
+        private void CopyIndices(BspTree tree, TargetArray target, int index3)
+        {
+            var source = tree.m_triangleVertexIndexArray;
+            var vertices = target.Via;
+            int start3 = index3;
+            int count = m_zeroList.Count;
+            for (int i = 0; i < count; i++)
+            {
+                int source3 = m_zeroList[i];
+                vertices[index3] = source[source3];
+                vertices[index3 + 1] = source[source3 + 1];
+                vertices[index3 + 2] = source[source3 + 2];
+                index3 += 3;
+            }
+            // Clear just this node's output during the same traversal. Vertex-only
+            // calls need neither a dummy attribute array nor a clearing pass.
+            if (target is TargetArrays arrays && arrays.Aia != null)
+                Array.Clear(arrays.Aia, start3 / 3, count);
+        }
+
+        private void CopyIndices(BspTree tree, TargetArrays target, int index)
+        {
+            var source = tree.m_triangleVertexIndexArray;
+            var sourceAttributes = tree.m_triangleAttributeIndexArray;
+            var vertices = target.Via;
+            var attributes = target.Aia;
+            int index3 = index * 3;
+            int count = m_zeroList.Count;
+            for (int i = 0; i < count; i++)
+            {
+                int sourceIndex = m_zeroList[i];
+                int source3 = sourceIndex * 3;
+                vertices[index3] = source[source3];
+                vertices[index3 + 1] = source[source3 + 1];
+                vertices[index3 + 2] = source[source3 + 2];
+                if (attributes != null) attributes[index] = sourceAttributes[sourceIndex];
+                index3 += 3;
+                index++;
+            }
+        }
+
         internal void SortBackToFront(
             BspTree t, TargetArray via,
             int ti3, V3d eye, bool mainTask, Action<Action> runChild)
@@ -684,39 +780,21 @@ namespace Aardvark.Geometry
             if (height >= 0.0)
             {
                 ti3 += m_negativeCount;
-                foreach (int tiMul3 in m_zeroList)
-                {
-                    t.GetTriangleVertexIndices(tiMul3,
-                        out via.Via[ti3],
-                        out via.Via[ti3 + 1],
-                        out via.Via[ti3 + 2]);
-                    ti3 += 3;
-                }
+                CopyIndices(t, via, ti3);
+                ti3 += m_zeroList.Count * 3;
             }
             else
             {
                 nti3 += m_positiveCount;
-                foreach (int tiMul3 in m_zeroList)
-                {
-                    t.GetTriangleVertexIndices(tiMul3,
-                        out via.Via[nti3],
-                        out via.Via[nti3 + 1],
-                        out via.Via[nti3 + 2]);
-                    nti3 += 3;
-                }
+                CopyIndices(t, via, nti3);
+                nti3 += m_zeroList.Count * 3;
             }
+
             if (m_negativeTree != null)
             {
                 if (mainTask && m_negativeCount < c_taskChunkSize)
                 {
-                    // via.Count += 1;
-					via.Finished.AddCount(1);
-                    runChild(() =>
-                    {
-                        m_negativeTree.SortBackToFront(
-                            t, via, nti3, eye, false, runChild);
-                        via.Finished.Signal();
-                    });
+                    m_negativeTree.ScheduleSort(t, via, nti3, eye, true, runChild);
                 }
                 else
                     m_negativeTree.SortBackToFront(
@@ -726,14 +804,7 @@ namespace Aardvark.Geometry
             {
                 if (mainTask && m_positiveCount < c_taskChunkSize)
                 {
-                    // via.Count += 1;
-					via.Finished.AddCount(1);
-                    runChild(() =>
-                    {
-                        m_positiveTree.SortBackToFront(
-                            t, via, ti3, eye, false, runChild);
-                        via.Finished.Signal();
-                    });
+                    m_positiveTree.ScheduleSort(t, via, ti3, eye, true, runChild);
                 }
                 else
                     m_positiveTree.SortBackToFront(
@@ -750,38 +821,21 @@ namespace Aardvark.Geometry
             if (height < 0.0)
             {
                 ti3 += m_negativeCount;
-                foreach (int tiMul3 in m_zeroList)
-                {
-                    t.GetTriangleVertexIndices(tiMul3,
-                        out via.Via[ti3],
-                        out via.Via[ti3 + 1],
-                        out via.Via[ti3 + 2]);
-                    ti3 += 3;
-                }
+                CopyIndices(t, via, ti3);
+                ti3 += m_zeroList.Count * 3;
             }
             else
             {
                 nti3 += m_positiveCount;
-                foreach (int tiMul3 in m_zeroList)
-                {
-                    t.GetTriangleVertexIndices(tiMul3,
-                        out via.Via[nti3],
-                        out via.Via[nti3 + 1],
-                        out via.Via[nti3 + 2]);
-                    nti3 += 3;
-                }
+                CopyIndices(t, via, nti3);
+                nti3 += m_zeroList.Count * 3;
             }
+
             if (m_positiveTree != null)
             {
                 if (mainTask && m_positiveCount < c_taskChunkSize)
                 {
-					via.Finished.AddCount(1);
-                    runChild(() =>
-                    {
-                        m_positiveTree.SortFrontToBack(
-                            t, via, ti3, eye, false, runChild);
-                        via.Finished.Signal();
-                    });
+                    m_positiveTree.ScheduleSort(t, via, ti3, eye, false, runChild);
                 }
                 else
                     m_positiveTree.SortFrontToBack(
@@ -791,13 +845,7 @@ namespace Aardvark.Geometry
             {
                 if (mainTask && m_negativeCount < c_taskChunkSize)
                 {
-					via.Finished.AddCount(1);
-                    runChild(() =>
-                    {
-                        m_negativeTree.SortFrontToBack(
-                            t, via, nti3, eye, false, runChild);
-                        via.Finished.Signal();
-                    });
+                    m_negativeTree.ScheduleSort(t, via, nti3, eye, false, runChild);
                 }
                 else
                     m_negativeTree.SortFrontToBack(
@@ -805,11 +853,6 @@ namespace Aardvark.Geometry
             }
         }
 
-        /// <summary>
-        /// Note, that the parallel implementation of this method could be
-        /// optimized, by providing separate node types for parallel and non
-        /// parallel execution.
-        /// </summary>
         internal void SortBackToFront(
             BspTree t, TargetArrays target,
             int ti, V3d eye, bool mainTask, Action<Action> runChild)
@@ -819,44 +862,20 @@ namespace Aardvark.Geometry
             if (height >= 0.0)
             {
                 ti += m_negativeCount;
-                var ti3 = ti * 3;
-                foreach (int oti in m_zeroList)
-                {
-                    t.GetTriangleVertexIndices(oti * 3,
-                        out target.Via[ti3],
-                        out target.Via[ti3 + 1],
-                        out target.Via[ti3 + 2]);
-                    ti3 += 3;
-                    target.Aia[ti] = (t.m_triangleAttributeIndexArray != null) ? t.m_triangleAttributeIndexArray[oti] : 0;
-                    ti++;
-                }
+                CopyIndices(t, target, ti);
+                ti += m_zeroList.Count;
             }
             else
             {
                 nti += m_positiveCount;
-                var nti3 = nti * 3;
-                foreach (int oti in m_zeroList)
-                {
-                    t.GetTriangleVertexIndices(oti * 3,
-                        out target.Via[nti3],
-                        out target.Via[nti3 + 1],
-                        out target.Via[nti3 + 2]);
-                    nti3 += 3;
-                    target.Aia[nti] = (t.m_triangleAttributeIndexArray != null) ? t.m_triangleAttributeIndexArray[oti] : 0;
-                    nti++;
-                }
+                CopyIndices(t, target, nti);
+                nti += m_zeroList.Count;
             }
             if (m_negativeTree != null)
             {
                 if (mainTask && m_negativeCount < c_taskChunkSize)
                 {
-					target.Finished.AddCount(1);
-                    runChild(() => 
-                    { 
-                        m_negativeTree.SortBackToFront(
-                            t, target, nti, eye, false, runChild);
-                        target.Finished.Signal();
-                    });
+                    m_negativeTree.ScheduleSort(t, target, nti, eye, true, runChild);
                 }
                 else
                     m_negativeTree.SortBackToFront(
@@ -866,13 +885,7 @@ namespace Aardvark.Geometry
             {
                 if (mainTask && m_positiveCount < c_taskChunkSize)
                 {
-					target.Finished.AddCount(1);
-                    runChild(() =>
-                    {
-                        m_positiveTree.SortBackToFront(
-                            t, target, ti, eye, false, runChild);
-                        target.Finished.Signal();
-                    });
+                    m_positiveTree.ScheduleSort(t, target, ti, eye, true, runChild);
                 }
                 else
                     m_positiveTree.SortBackToFront(
@@ -889,44 +902,20 @@ namespace Aardvark.Geometry
             if (height < 0.0)
             {
                 ti += m_negativeCount;
-                var ti3 = ti * 3;
-                foreach (int oti in m_zeroList)
-                {
-                    t.GetTriangleVertexIndices(oti * 3,
-                        out target.Via[ti3],
-                        out target.Via[ti3 + 1],
-                        out target.Via[ti3 + 2]);
-                    ti3 += 3;
-                    target.Aia[ti] = (t.m_triangleAttributeIndexArray != null) ? t.m_triangleAttributeIndexArray[oti] : 0;
-                    ti++;
-                }
+                CopyIndices(t, target, ti);
+                ti += m_zeroList.Count;
             }
             else
             {
                 nti += m_positiveCount;
-                var nti3 = nti * 3;
-                foreach (int oti in m_zeroList)
-                {
-                    t.GetTriangleVertexIndices(oti * 3,
-                        out target.Via[nti3],
-                        out target.Via[nti3 + 1],
-                        out target.Via[nti3 + 2]);
-                    nti3 += 3;
-                    target.Aia[nti] = (t.m_triangleAttributeIndexArray != null) ? t.m_triangleAttributeIndexArray[oti] : 0;
-                    nti++;
-                }
+                CopyIndices(t, target, nti);
+                nti += m_zeroList.Count;
             }
             if (m_positiveTree != null)
             {
                 if (mainTask && m_positiveCount < c_taskChunkSize)
                 {
-					target.Finished.AddCount(1);
-                    runChild (() => 
-                    {
-                        m_positiveTree.SortFrontToBack(
-                            t, target, ti, eye, false, runChild);
-                        target.Finished.Signal();
-                    });
+                    m_positiveTree.ScheduleSort(t, target, ti, eye, false, runChild);
                 }
                 else
                     m_positiveTree.SortFrontToBack(
@@ -936,14 +925,7 @@ namespace Aardvark.Geometry
             {
                 if (mainTask && m_negativeCount < c_taskChunkSize)
                 {
-					target.Finished.AddCount(1);
-                    runChild(() =>
-                    {
-                        m_negativeTree.SortFrontToBack(
-                            t, target, nti, eye, false, runChild);
-                        target.Finished.Signal();
-                    }
-                    );
+                    m_negativeTree.ScheduleSort(t, target, nti, eye, false, runChild);
                 }
                 else
                     m_negativeTree.SortFrontToBack(


### PR DESCRIPTION
## Fix

Finalized BSP trees encode node indices/counts in different units depending on attribute presence. Both output APIs now select the stored layout correctly, preserve split-fragment IDs, and emit zeros when attributes are absent. Public signatures and serialized representations are unchanged.

The sort remains a single read-only traversal: no dummy arrays or repacking. Shared copy loops cache buffer references, closures are allocated only for scheduled subtrees, and parallel work no longer depends on the caller's task scheduler.

## Coverage and performance

- 180 BSP regressions cover the layout/API/order/parallelism matrix, both viewpoints, coplanarity, both children, splits, concurrent calls, task thresholds, and historical serialized fixtures.
- Sorting, copying, and scheduling have 100% line and branch coverage. Full Release and Debug suites each pass 622 tests, with 2 existing skips.
- Against unchanged `7c9ea62`, all 16 representative serial/parallel workloads improve: median paired elapsed time falls 26.2–66.8%, with lower allocations throughout. Balanced-tree allocations fall by more than 99.6%.
- XML/reference documentation now explains cross-layout behavior and finalized output sizing; the release note is above the existing version headers.

Closes #85.

[Detailed benchmark results](https://github.com/aardvark-platform/aardvark.algodat/issues/85#issuecomment-5574074188)

Implementation: 8971e47bca86f0faa69033f2c2711ee3537d0a98
