### PR TITLE
Hash stored plane coefficients and preserve hull boundaries

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,5 @@
+- [PointSet] Repair plane/hull fingerprints; invalidate caches using old geometry fingerprints (#95).
+
 ### 5.6.3
 - Updated SharpCompress to 0.48.1 to address CVE-2026-44788
 

--- a/ai/POINT_CLOUDS.md
+++ b/ai/POINT_CLOUDS.md
@@ -206,6 +206,16 @@ var merged = pointSet1.Merge(
 );
 ```
 
+### Geometry Fingerprints
+
+`Plane3d.ComputeMd5Hash()` encodes the stored `Normal.X`, `Normal.Y`, `Normal.Z`, and `Distance` as four little-endian IEEE 754 doubles, in that order. It does not derive `Plane.Point`, normalize coefficients, or canonicalize signed zeros/NaN payloads. Plane arrays and enumerables concatenate these 32-byte records in input order; a singleton matches its scalar plane.
+
+`Hull3d.ComputeMd5Hash()` prefixes each hull with its little-endian Int32 plane count, then writes its ordered plane records. Hull arrays/enumerables concatenate those framed hull records without an outer count. This preserves hull grouping, empty hulls, and ordering; an empty collection differs from one empty hull, while a valid scalar hull matches its singleton collection. These are representation fingerprints, not canonical geometric-equivalence tests.
+
+The MD5 digest bytes are returned as a `Guid`. Scalar invalid hulls (`PlaneArray == null`) and null hull collections retain `Guid.Empty`; invalid hull elements in collections still throw `NullReferenceException`. Null plane collections also retain their `NullReferenceException` behavior. Empty collections hash the empty byte sequence. Sequences are traversed once, using a bounded pooled buffer rather than materializing/counting the input.
+
+**Compatibility:** Plane and hull fingerprints intentionally change from the old Point-based, unframed encoding. Callers must invalidate caches keyed by those old geometry fingerprints. Vector/color fingerprints, `FileHelpers.ComputeMd5Hash`, and file-import storage keys are unchanged.
+
 ### Custom Storage Backend
 
 ```csharp

--- a/src/Aardvark.Algodat.Tests/HashTests.cs
+++ b/src/Aardvark.Algodat.Tests/HashTests.cs
@@ -15,12 +15,349 @@ using Aardvark.Base;
 using Aardvark.Geometry.Points;
 using NUnit.Framework;
 using NUnit.Framework.Legacy;
+using System;
+using System.Buffers.Binary;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Threading.Tasks;
 
 namespace Aardvark.Geometry.Tests
 {
     [TestFixture]
     public class HashTests
     {
+        private static readonly Guid EmptyDigest = new("d98c1dd4-008f-04b2-e980-0998ecf8427e");
+        private static readonly Plane3d A = new(new V3d(1, -2, 3.5), -4.25);
+        private static readonly Plane3d B = new(new V3d(0, 1, 0), 0);
+        private static readonly Hull3d EmptyHull = new(Array.Empty<Plane3d>());
+
+        // Independent encoding oracle: explicit bit patterns/byte offsets, not
+        // BinaryWriter, Plane.Point, or another production hash overload.
+        private static byte[] PlaneBytes(params Plane3d[] planes)
+        {
+            var bytes = new byte[32 * planes.Length];
+            for (var i = 0; i < planes.Length; i++)
+            {
+                var p = planes[i];
+                var fields = new[] { p.Normal.X, p.Normal.Y, p.Normal.Z, p.Distance };
+                for (var j = 0; j < 4; j++)
+                    BinaryPrimitives.WriteInt64LittleEndian(bytes.AsSpan(32 * i + 8 * j), BitConverter.DoubleToInt64Bits(fields[j]));
+            }
+            return bytes;
+        }
+
+        private static Guid ExpectedPlanes(params Plane3d[] planes) => new(MD5.HashData(PlaneBytes(planes)));
+
+        private static Guid ExpectedHulls(params Hull3d[] hulls)
+        {
+            var bytes = new List<byte>();
+            foreach (var hull in hulls)
+            {
+                var prefix = new byte[4];
+                BinaryPrimitives.WriteInt32LittleEndian(prefix, hull.PlaneArray.Length);
+                bytes.AddRange(prefix);
+                bytes.AddRange(PlaneBytes(hull.PlaneArray));
+            }
+            return new Guid(MD5.HashData(bytes.ToArray()));
+        }
+
+        private sealed class OneShot<T> : IEnumerable<T>
+        {
+            private readonly T[] values;
+            public OneShot(T[] values) { this.values = values; }
+            public int Enumerations;
+            public int Yielded;
+            public int Disposals;
+            public IEnumerator<T> GetEnumerator()
+            {
+                if (++Enumerations != 1) throw new InvalidOperationException("Sequence enumerated twice.");
+                return Iterate().GetEnumerator();
+            }
+            private IEnumerable<T> Iterate()
+            {
+                try { foreach (var value in values) { Yielded++; yield return value; } }
+                finally { Disposals++; }
+            }
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        }
+
+        [Test]
+        public void PerpendicularOriginPlanesHaveDistinctFingerprints()
+        {
+            var planes = new[] { Plane3d.XPlane, Plane3d.YPlane, Plane3d.ZPlane };
+            Assert.That(planes.Select(x => x.ComputeMd5Hash()).Distinct().Count(), Is.EqualTo(3));
+            Assert.That(planes.Select(x => x.ComputeMd5Hash()), Is.EqualTo(new[] {
+                new Guid("0986904c-8ef4-66b8-27f7-56b53418f4f7"),
+                new Guid("52d7f6da-10fd-8900-3737-7108c4bfd6d8"),
+                new Guid("b796f78a-c24e-2a49-271d-9d3d1e1ebad1") }));
+        }
+
+        [Test]
+        public void EveryStoredCoefficientChangesTheHash([Values(0, 1, 2, 3)] int field)
+        {
+            var original = new Plane3d(new V3d(1, 2, 3), 0);
+            var changed = original;
+            if (field == 3) changed.Distance = 7;
+            else changed.Normal[field] = 7;
+            Assert.That(changed.ComputeMd5Hash(), Is.Not.EqualTo(original.ComputeMd5Hash()));
+            Assert.That(changed.ComputeMd5Hash(), Is.EqualTo(ExpectedPlanes(changed)));
+        }
+
+        [Test]
+        public void StoredBitsAreNotNormalized([Values(0, 1, 2, 3)] int field,
+            [Values(0L, long.MinValue, 1L, 0x7ff0000000000000L, 0x7ff8000000000001L, 0x7ff8000000000002L)] long bits)
+        {
+            var plane = A;
+            if (field == 3) plane.Distance = BitConverter.Int64BitsToDouble(bits);
+            else plane.Normal[field] = BitConverter.Int64BitsToDouble(bits);
+            var before = PlaneBytes(plane);
+            Assert.That(plane.ComputeMd5Hash(), Is.EqualTo(ExpectedPlanes(plane)));
+            Assert.That(new[] { plane }.ComputeMd5Hash(), Is.EqualTo(plane.ComputeMd5Hash()));
+            Assert.That(PlaneBytes(plane), Is.EqualTo(before));
+        }
+
+        [Test]
+        public void ScaledCoefficientsAndSignedZerosRemainDistinct()
+        {
+            var unit = Plane3d.XPlane;
+            var scaled = new Plane3d(2 * unit.Normal, 0);
+            Assert.That(scaled.ComputeMd5Hash(), Is.Not.EqualTo(unit.ComputeMd5Hash()));
+            var negativeZero = unit;
+            negativeZero.Distance = BitConverter.Int64BitsToDouble(long.MinValue);
+            Assert.That(negativeZero.ComputeMd5Hash(), Is.Not.EqualTo(unit.ComputeMd5Hash()));
+            Assert.That(A.ComputeMd5Hash(), Is.EqualTo(new Guid("31ebe777-2dc3-cf4e-d64e-601b95d388c3")));
+        }
+
+        [Test]
+        public void PlaneSequencesMatchTheirEncoding([Values(0, 1, 2, 7, 8, 9, 31, 32, 33, 127, 128, 129, 257)] int count)
+        {
+            var planes = Enumerable.Range(0, count).Select(i => new Plane3d(new V3d(i + 1, -i, i / 2.0), i - 8.25)).ToArray();
+            var sequence = new OneShot<Plane3d>(planes);
+            var expected = ExpectedPlanes(planes);
+            Assert.That(planes.ComputeMd5Hash(), Is.EqualTo(expected));
+            Assert.That(sequence.ComputeMd5Hash(), Is.EqualTo(expected));
+            Assert.That(sequence.Enumerations, Is.EqualTo(1));
+            Assert.That(sequence.Yielded, Is.EqualTo(count));
+            Assert.That(sequence.Disposals, Is.EqualTo(1));
+            if (count == 1) Assert.That(planes[0].ComputeMd5Hash(), Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void HullCountAndCoefficientEncodingIsShared([Values(0, 1, 2, 7, 8, 31, 32, 127, 128, 255, 256, 257)] int count)
+        {
+            var planes = Enumerable.Range(0, count).Select(i => new Plane3d(new V3d(i + 1, 2, -3), i)).ToArray();
+            var hull = new Hull3d(planes);
+            var before = PlaneBytes(planes);
+            var sequence = new OneShot<Hull3d>(new[] { hull });
+            var expected = ExpectedHulls(hull);
+            Assert.That(hull.ComputeMd5Hash(), Is.EqualTo(expected));
+            Assert.That(new[] { hull }.ComputeMd5Hash(), Is.EqualTo(expected));
+            Assert.That(sequence.ComputeMd5Hash(), Is.EqualTo(expected));
+            Assert.That(sequence.Enumerations, Is.EqualTo(1));
+            Assert.That(sequence.Yielded, Is.EqualTo(1));
+            Assert.That(sequence.Disposals, Is.EqualTo(1));
+            Assert.That(hull.PlaneArray, Is.SameAs(planes));
+            Assert.That(PlaneBytes(planes), Is.EqualTo(before));
+        }
+
+        [Test]
+        public void HullGoldenFingerprintsIncludeFraming()
+        {
+            Assert.That(EmptyHull.ComputeMd5Hash(), Is.EqualTo(new Guid("84ffd3f1-2943-3277-862d-f21dc4e57262")));
+            Assert.That(new Hull3d(new[] { A }).ComputeMd5Hash(), Is.EqualTo(new Guid("f4f0176d-374b-bdae-f575-7a9332915af5")));
+            Assert.That(new Hull3d(new[] { Plane3d.XPlane, Plane3d.YPlane, Plane3d.ZPlane }).ComputeMd5Hash(), Is.EqualTo(new Guid("8466d5f9-3acc-814e-647d-1baa79033404")));
+        }
+
+        [Test]
+        public void HullGroupingAffectsTheFingerprint()
+        {
+            var c = Plane3d.ZPlane;
+            var left = new[] { new Hull3d(new[] { A }), new Hull3d(new[] { B, c }) };
+            var right = new[] { new Hull3d(new[] { A, B }), new Hull3d(new[] { c }) };
+            Assert.That(left.ComputeMd5Hash(), Is.Not.EqualTo(right.ComputeMd5Hash()));
+            Assert.That(left.ComputeMd5Hash(), Is.EqualTo(ExpectedHulls(left)));
+            Assert.That(right.ComputeMd5Hash(), Is.EqualTo(ExpectedHulls(right)));
+        }
+
+        [Test]
+        public void InsertingEmptyHullsAffectsTheFingerprint([Values(0, 1, 2)] int index)
+        {
+            var original = new[] { new Hull3d(new[] { A }), new Hull3d(new[] { B }) };
+            var inserted = original.Take(index).Concat(new[] { EmptyHull }).Concat(original.Skip(index)).ToArray();
+            Assert.That(inserted.ComputeMd5Hash(), Is.Not.EqualTo(original.ComputeMd5Hash()));
+            Assert.That(inserted.ComputeMd5Hash(), Is.EqualTo(ExpectedHulls(inserted)));
+        }
+
+        [Test]
+        public void PlaneHullAndEmptyHullOrderIsSignificant()
+        {
+            Assert.That(new[] { A, B }.ComputeMd5Hash(), Is.Not.EqualTo(new[] { B, A }.ComputeMd5Hash()));
+            Assert.That(new Hull3d(new[] { A, B }).ComputeMd5Hash(), Is.Not.EqualTo(new Hull3d(new[] { B, A }).ComputeMd5Hash()));
+            var a = new Hull3d(new[] { A }); var b = new Hull3d(new[] { B });
+            Assert.That(new[] { a, b }.ComputeMd5Hash(), Is.Not.EqualTo(new[] { b, a }.ComputeMd5Hash()));
+            Assert.That(new[] { a, EmptyHull }.ComputeMd5Hash(), Is.Not.EqualTo(new[] { EmptyHull, a }.ComputeMd5Hash()));
+        }
+
+        [Test]
+        public void HullSequencesAreConsumedOnce([Values(0, 1, 2, 31, 128, 257)] int count)
+        {
+            var hulls = Enumerable.Range(0, count).Select(i => new Hull3d(Enumerable.Repeat(A, i % 5).ToArray())).ToArray();
+            var sequence = new OneShot<Hull3d>(hulls);
+            Assert.That(hulls.ComputeMd5Hash(), Is.EqualTo(ExpectedHulls(hulls)));
+            Assert.That(sequence.ComputeMd5Hash(), Is.EqualTo(ExpectedHulls(hulls)));
+            Assert.That(sequence.Enumerations, Is.EqualTo(1));
+            Assert.That(sequence.Yielded, Is.EqualTo(count));
+            Assert.That(sequence.Disposals, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void ExistingNullAndInvalidContractsArePreserved()
+        {
+            Assert.Throws<NullReferenceException>(() => ((Plane3d[])null).ComputeMd5Hash());
+            Assert.Throws<NullReferenceException>(() => ((IEnumerable<Plane3d>)null).ComputeMd5Hash());
+            Assert.That(((Hull3d[])null).ComputeMd5Hash(), Is.EqualTo(Guid.Empty));
+            Assert.That(((IEnumerable<Hull3d>)null).ComputeMd5Hash(), Is.EqualTo(Guid.Empty));
+            Assert.That(Hull3d.Invalid.ComputeMd5Hash(), Is.EqualTo(Guid.Empty));
+            Assert.That(default(Hull3d).ComputeMd5Hash(), Is.EqualTo(Guid.Empty));
+            Assert.That(Plane3d.Invalid.ComputeMd5Hash(), Is.EqualTo(ExpectedPlanes(Plane3d.Invalid)));
+            Assert.That(Plane3d.Invalid.ComputeMd5Hash(), Is.Not.EqualTo(Guid.Empty));
+        }
+
+        [Test]
+        public void InvalidHullElementsThrowAndDisposeEnumeration([Values(0, 1, 2)] int position)
+        {
+            var hulls = new[] { EmptyHull, EmptyHull, EmptyHull };
+            hulls[position] = Hull3d.Invalid;
+            Assert.Throws<NullReferenceException>(() => hulls.ComputeMd5Hash());
+            var sequence = new OneShot<Hull3d>(hulls);
+            Assert.Throws<NullReferenceException>(() => sequence.ComputeMd5Hash());
+            Assert.That(sequence.Enumerations, Is.EqualTo(1));
+            Assert.That(sequence.Yielded, Is.EqualTo(position + 1));
+            Assert.That(sequence.Disposals, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void EmptySequencesDifferFromOneEmptyHull()
+        {
+            Assert.That(Array.Empty<Plane3d>().ComputeMd5Hash(), Is.EqualTo(EmptyDigest));
+            Assert.That(Array.Empty<Hull3d>().ComputeMd5Hash(), Is.EqualTo(EmptyDigest));
+            Assert.That(new OneShot<Hull3d>(Array.Empty<Hull3d>()).ComputeMd5Hash(), Is.EqualTo(EmptyDigest));
+            Assert.That(new[] { EmptyHull }.ComputeMd5Hash(), Is.Not.EqualTo(EmptyDigest));
+            Assert.That(new[] { EmptyHull }.ComputeMd5Hash(), Is.EqualTo(EmptyHull.ComputeMd5Hash()));
+            Assert.That(new[] { EmptyHull, EmptyHull }.ComputeMd5Hash(), Is.Not.EqualTo(EmptyHull.ComputeMd5Hash()));
+        }
+
+        [Test]
+        public void EnumerationDoesNotAllocatePerElement([Values(16, 4096)] int count, [Values(false, true)] bool hulls)
+        {
+            var planes = Enumerable.Repeat(A, count).ToArray();
+            var hs = Enumerable.Repeat(new Hull3d(new[] { A }), count).ToArray();
+            Func<Guid> array = hulls ? () => hs.ComputeMd5Hash() : () => planes.ComputeMd5Hash();
+            Func<Guid> sequence = hulls ? () => ((IEnumerable<Hull3d>)hs).ComputeMd5Hash() : () => ((IEnumerable<Plane3d>)planes).ComputeMd5Hash();
+            for (var i = 0; i < 8; i++) { array(); sequence(); }
+            long Allocated(Func<Guid> f)
+            {
+                var before = GC.GetAllocatedBytesForCurrentThread();
+                for (var i = 0; i < 8; i++) f();
+                return (GC.GetAllocatedBytesForCurrentThread() - before) / 8;
+            }
+            Assert.That(Allocated(sequence) - Allocated(array), Is.InRange(0, 128));
+        }
+
+        [Test]
+        public void GeometryHashingUsesBoundedWorkingMemory([Values(127, 128, 129, 1024, 65536)] int count, [Values(false, true)] bool hulls)
+        {
+            var planes = Enumerable.Repeat(A, count).ToArray();
+            var hs = Enumerable.Repeat(new Hull3d(new[] { A }), count).ToArray();
+            Func<Guid> hash = hulls ? () => hs.ComputeMd5Hash() : () => planes.ComputeMd5Hash();
+            var expected = hulls ? ExpectedHulls(hs) : ExpectedPlanes(planes);
+            for (var i = 0; i < 4; i++) Assert.That(hash(), Is.EqualTo(expected));
+            var before = GC.GetAllocatedBytesForCurrentThread();
+            for (var i = 0; i < 4; i++) hash();
+            var perCall = (GC.GetAllocatedBytesForCurrentThread() - before) / 4;
+            Assert.That(perCall, Is.LessThanOrEqualTo(1024), "do not buffer/materialize the whole input");
+        }
+
+        [Test]
+        public void RecycledBuffersDoNotLeakEarlierDataOrFailedSequences([Values(false, true)] bool failAfterFlush)
+        {
+            IEnumerable<Plane3d> Input()
+            {
+                for (var i = 0; i < 257; i++) yield return A;
+                if (failAfterFlush) throw new ApplicationException("sequence failure");
+            }
+            if (failAfterFlush) Assert.Throws<ApplicationException>(() => Input().ComputeMd5Hash());
+            else Assert.That(Input().ComputeMd5Hash(), Is.EqualTo(ExpectedPlanes(Enumerable.Repeat(A, 257).ToArray())));
+            Assert.That(B.ComputeMd5Hash(), Is.EqualTo(ExpectedPlanes(B)));
+            Assert.That(EmptyHull.ComputeMd5Hash(), Is.EqualTo(ExpectedHulls(EmptyHull)));
+            Assert.That(Array.Empty<Plane3d>().ComputeMd5Hash(), Is.EqualTo(EmptyDigest));
+        }
+
+        [Test]
+        public void ReentrantEnumerationKeepsIndependentHashState()
+        {
+            IEnumerable<Plane3d> Input()
+            {
+                for (var i = 0; i < 257; i++)
+                {
+                    Assert.That(new Hull3d(new[] { B }).ComputeMd5Hash(), Is.EqualTo(ExpectedHulls(new Hull3d(new[] { B }))));
+                    yield return A;
+                }
+            }
+            Assert.That(Input().ComputeMd5Hash(), Is.EqualTo(ExpectedPlanes(Enumerable.Repeat(A, 257).ToArray())));
+        }
+
+        [Test]
+        public void ConcurrentCallsKeepIndependentHashState()
+        {
+            Parallel.For(0, 8, new ParallelOptions { MaxDegreeOfParallelism = 4 }, i =>
+            {
+                var planes = Enumerable.Range(0, 129 + i).Select(j => new Plane3d(new V3d(i + 1, j, -3), j - i)).ToArray();
+                var expected = ExpectedPlanes(planes);
+                for (var round = 0; round < 8; round++) Assert.That(planes.ComputeMd5Hash(), Is.EqualTo(expected));
+            });
+        }
+
+        public static IEnumerable<TestCaseData> VectorColorGoldens()
+        {
+            yield return new(new V2f(1.25f, -2.5f), "460e5921-56b0-9e58-84cb-53ed76b09e58", "40c61419-6878-61e2-a5c4-f7447c13deac");
+            yield return new(new V2d(1.25, -2.5), "ecb315e5-1400-2104-1eb4-21c1f7caa4f2", "852c6d46-b16c-9eff-21fa-5b51492ba70d");
+            yield return new(new V2i(-123456789, 42), "61bbc2c9-5bac-24c6-07e8-42ca78c38c38", "8d343978-4950-1597-0886-38c724402f21");
+            yield return new(new V2l(-12345678901234567L, 1152921504606846977L), "e8eb24c7-b3ab-0443-e459-331afbf85a7f", "4ee9a489-d89f-bc92-24f5-a02b0c48d760");
+            yield return new(new V3f(1.25f, -2.5f, 3.75f), "272ed5ed-b25f-a604-c7b0-7fa2aad5a022", "20ced9cf-e0e4-2283-c595-bcf7391b7d11");
+            yield return new(new V3d(1.25, -2.5, 3.75), "cd5b6dd7-62fa-b087-9e72-5a531e878a04", "35490e6d-6c79-132d-7c7b-69016042262a");
+            yield return new(new V3i(-123456789, 42, -7), "319a677f-7abf-c688-0bb6-51d3c9cda3eb", "66488229-1e1a-4337-f3a6-ebe31e35dde0");
+            yield return new(new V3l(-12345678901234567L, 1152921504606846977L, -7L), "664fbc3b-1251-2996-50dd-b14718706c1f", "f5acaa44-dd5d-7056-2526-7f75a7cb82c3");
+            yield return new(new V4f(1.25f, -2.5f, 3.75f, -4.5f), "a0e812f2-e715-3c10-c69a-b0cf79033335", "b1170319-3990-6bfc-11a4-a3e04f92240b");
+            yield return new(new V4d(1.25, -2.5, 3.75, -4.5), "90a5305e-d7b4-fe3b-b87a-eca56d9d99cc", "8bf8737f-2dda-9465-cba6-0e74ddc436d0");
+            yield return new(new V4i(-123456789, 42, -7, 12345), "973cb8db-424c-4e69-2588-6e91d2206d27", "147705a2-7f98-3bcf-4d9b-26795432343a");
+            yield return new(new V4l(-12345678901234567L, 1152921504606846977L, -7L, 12345L), "ffd0b05f-0cf4-b539-9013-2675709afb5f", "e86ee5ad-89ff-3fc4-dd1c-de402ae7328f");
+            yield return new(new C3b(1, 2, 200), "d928c6f0-05bb-5d80-edbf-25ebde831087", "0c9ffca2-813c-b274-373d-9463c7ffc551");
+            yield return new(new C3f(0.25f, 0.5f, 0.75f), "cda5c47e-d78f-75fd-3de0-4073902a89a5", "e082d876-edf5-0e0f-1973-7dc4064b4575");
+            yield return new(new C4b(1, 2, 200, 255), "352fc21a-d3da-1752-b617-e6c6d3443473", "d687dcbb-51eb-207a-533e-7074b9dab9f0");
+            yield return new(new C4f(0.25f, 0.5f, 0.75f, 1f), "2dbdc84a-7c53-0502-503b-e47d2b19d742", "ffb9a1b8-3e44-ec18-d6e1-d73de2e2dac1");
+        }
+
+        [TestCaseSource(nameof(VectorColorGoldens))]
+        public void VectorAndColorFingerprintsRemainUnchanged(object value, string scalarGolden, string pairGolden)
+        {
+            var type = value.GetType();
+            Guid Hash(Type inputType, object input) => (Guid)typeof(HashExtensions).GetMethod(nameof(HashExtensions.ComputeMd5Hash), new[] { inputType }).Invoke(null, new[] { input });
+            var single = Array.CreateInstance(type, 1); single.SetValue(value, 0);
+            var pair = Array.CreateInstance(type, 2); pair.SetValue(value, 0); pair.SetValue(value, 1);
+            var enumerableType = typeof(IEnumerable<>).MakeGenericType(type);
+            Assert.That(Hash(type, value), Is.EqualTo(new Guid(scalarGolden)));
+            Assert.That(Hash(single.GetType(), single), Is.EqualTo(new Guid(scalarGolden)));
+            Assert.That(Hash(enumerableType, single), Is.EqualTo(new Guid(scalarGolden)));
+            Assert.That(Hash(pair.GetType(), pair), Is.EqualTo(new Guid(pairGolden)));
+            Assert.That(Hash(enumerableType, pair), Is.EqualTo(new Guid(pairGolden)));
+            Assert.That(Hash(single.GetType(), Array.CreateInstance(type, 0)), Is.EqualTo(EmptyDigest));
+            Assert.That(Hash(single.GetType(), null), Is.EqualTo(Guid.Empty));
+            Assert.That(Hash(enumerableType, null), Is.EqualTo(Guid.Empty));
+        }
+
         [Test]
         public void HashOfHull3d_Invalid_Equals_Invalid()
         {

--- a/src/Aardvark.Geometry.PointSet/Utils/HashExtensions.cs
+++ b/src/Aardvark.Geometry.PointSet/Utils/HashExtensions.cs
@@ -12,6 +12,8 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 using System;
+using System.Buffers;
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.CompilerServices;
@@ -342,88 +344,145 @@ public static class HashExtensions
 
     #region Plane3d
 
-    /// <summary>Computes MD5 hash of given data.</summary>
+    /// <summary>
+    /// Hashes the stored Normal.X, Normal.Y, Normal.Z and Distance as four
+    /// little-endian IEEE 754 doubles, without normalization. The digest bytes
+    /// form a Guid. This replaces the old Point-based fingerprint; callers must
+    /// invalidate caches keyed by the old plane/hull fingerprints.
+    /// </summary>
     public static Guid ComputeMd5Hash(this Plane3d plane)
-    {
-        return ComputeMd5Hash(bw => {
-            bw.Write(plane.Point.X); bw.Write(plane.Point.Y); bw.Write(plane.Point.Z);
-            bw.Write(plane.Distance);
-        });
-    }
-    /// <summary>Computes MD5 hash of given data.</summary>
+        => ComputeGeometryHash(writer => writer.WritePlane(plane));
+
+    /// <summary>
+    /// Hashes ordered plane coefficient records using the scalar encoding,
+    /// without a collection header. A singleton hashes like its scalar plane.
+    /// </summary>
+    /// <exception cref="NullReferenceException">The array is null.</exception>
     public static Guid ComputeMd5Hash(this Plane3d[] planes)
-    {
-        return ComputeMd5Hash(bw => {
-            foreach (var plane in planes)
-            {
-                bw.Write(plane.Point.X); bw.Write(plane.Point.Y); bw.Write(plane.Point.Z);
-                bw.Write(plane.Distance);
-            }
+        => ComputeGeometryHash(writer => {
+            foreach (var plane in planes) writer.WritePlane(plane);
         });
-    }
-    /// <summary>Computes MD5 hash of given data.</summary>
+
+    /// <summary>
+    /// Hashes ordered plane coefficient records using the scalar encoding,
+    /// enumerating the sequence once without a collection header.
+    /// </summary>
+    /// <exception cref="NullReferenceException">The sequence is null.</exception>
     public static Guid ComputeMd5Hash(this IEnumerable<Plane3d> planes)
-    {
-        return ComputeMd5Hash(bw => {
-            foreach (var plane in planes)
-            {
-                bw.Write(plane.Point.X); bw.Write(plane.Point.Y); bw.Write(plane.Point.Z);
-                bw.Write(plane.Distance);
-            }
+        => ComputeGeometryHash(writer => {
+            foreach (var plane in planes) writer.WritePlane(plane);
         });
-    }
 
     #endregion
 
     #region Hull3d
 
-    /// <summary>Computes MD5 hash of given data.</summary>
+    /// <summary>
+    /// Hashes the little-endian Int32 plane count followed by ordered plane
+    /// coefficient records, without normalization or reordering. An invalid hull
+    /// (null PlaneArray) returns Guid.Empty. This replaces the old unframed,
+    /// Point-based fingerprint; callers must invalidate caches using it.
+    /// </summary>
     public static Guid ComputeMd5Hash(this Hull3d hull)
     {
         if (hull.PlaneArray == null) return Guid.Empty;
-
-        return ComputeMd5Hash(bw => {
-            foreach (var plane in hull.PlaneArray)
-            {
-                bw.Write(plane.Point.X); bw.Write(plane.Point.Y); bw.Write(plane.Point.Z);
-                bw.Write(plane.Distance);
-            }
-        });
+        return ComputeGeometryHash(writer => writer.WriteHull(hull));
     }
-    /// <summary>Computes MD5 hash of given data.</summary>
+
+    /// <summary>
+    /// Hashes ordered hull records using the scalar count/coefficients encoding.
+    /// A valid singleton hashes like its scalar hull; an empty array differs from
+    /// one empty hull. A null array returns Guid.Empty.
+    /// </summary>
+    /// <exception cref="NullReferenceException">An element has a null PlaneArray.</exception>
     public static Guid ComputeMd5Hash(this Hull3d[] hulls)
     {
         if (hulls == null) return Guid.Empty;
-
-        return ComputeMd5Hash(bw => {
-            foreach (var hull in hulls)
-            {
-                foreach (var plane in hull.PlaneArray)
-                {
-                    bw.Write(plane.Point.X); bw.Write(plane.Point.Y); bw.Write(plane.Point.Z);
-                    bw.Write(plane.Distance);
-                }
-            }
+        return ComputeGeometryHash(writer => {
+            foreach (var hull in hulls) writer.WriteHull(hull);
         });
     }
-    /// <summary>Computes MD5 hash of given data.</summary>
+
+    /// <summary>
+    /// Hashes ordered hull records using the scalar count/coefficients encoding,
+    /// enumerating the sequence once. A null sequence returns Guid.Empty.
+    /// </summary>
+    /// <exception cref="NullReferenceException">An element has a null PlaneArray.</exception>
     public static Guid ComputeMd5Hash(this IEnumerable<Hull3d> hulls)
     {
         if (hulls == null) return Guid.Empty;
-
-        return ComputeMd5Hash(bw => {
-            foreach (var hull in hulls)
-            {
-                foreach (var plane in hull.PlaneArray)
-                {
-                    bw.Write(plane.Point.X); bw.Write(plane.Point.Y); bw.Write(plane.Point.Z);
-                    bw.Write(plane.Distance);
-                }
-            }
+        return ComputeGeometryHash(writer => {
+            foreach (var hull in hulls) writer.WriteHull(hull);
         });
     }
 
     #endregion
+
+    private static Guid ComputeGeometryHash(Action<GeometryHashWriter> writeData)
+    {
+        using var writer = new GeometryHashWriter();
+        writeData(writer);
+        return writer.Finish();
+    }
+
+    // Geometry framing can push a growing MemoryStream across a capacity boundary.
+    // Feed bounded batches to MD5 instead, with no input-size-dependent allocations
+    // or count pass. Keep unrelated vector/color hashing on its established path.
+    private sealed class GeometryHashWriter : IDisposable
+    {
+        private const int BufferSize = 4096;
+        private readonly byte[] m_buffer = ArrayPool<byte>.Shared.Rent(BufferSize);
+        private int m_count;
+        private IncrementalHash? m_hash;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void WritePlane(Plane3d plane)
+        {
+            var bytes = Reserve(32);
+            BinaryPrimitives.WriteInt64LittleEndian(bytes, BitConverter.DoubleToInt64Bits(plane.Normal.X));
+            BinaryPrimitives.WriteInt64LittleEndian(bytes.Slice(8), BitConverter.DoubleToInt64Bits(plane.Normal.Y));
+            BinaryPrimitives.WriteInt64LittleEndian(bytes.Slice(16), BitConverter.DoubleToInt64Bits(plane.Normal.Z));
+            BinaryPrimitives.WriteInt64LittleEndian(bytes.Slice(24), BitConverter.DoubleToInt64Bits(plane.Distance));
+        }
+
+        public void WriteHull(Hull3d hull)
+        {
+            var planes = hull.PlaneArray;
+            var count = planes.Length; // Invalid elements retain their NullReferenceException contract.
+            BinaryPrimitives.WriteInt32LittleEndian(Reserve(4), count);
+            foreach (var plane in planes) WritePlane(plane);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private Span<byte> Reserve(int size)
+        {
+            if (m_count + size > BufferSize) Flush();
+            var bytes = m_buffer.AsSpan(m_count, size);
+            m_count += size;
+            return bytes;
+        }
+
+        private void Flush()
+        {
+            // Lazy creation also keeps rented-buffer cleanup exception-safe if
+            // creating the platform hash provider fails.
+            m_hash ??= IncrementalHash.CreateHash(HashAlgorithmName.MD5);
+            m_hash.AppendData(m_buffer, 0, m_count);
+            m_count = 0;
+        }
+
+        public Guid Finish()
+        {
+            Flush();
+            return new Guid(m_hash!.GetHashAndReset());
+        }
+
+        public void Dispose()
+        {
+            m_hash?.Dispose();
+            ArrayPool<byte>.Shared.Return(m_buffer);
+        }
+    }
     
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static Guid ComputeMd5Hash(Action<BinaryWriter> writeDataToHash)


### PR DESCRIPTION
## Repair

Hash stored plane normals and distance instead of `Plane.Point`, and frame each ordered hull with its little-endian plane count. This distinguishes perpendicular origin planes, hull grouping, and inserted empty hulls while preserving coefficient bits, ordering, null/invalid contracts, and valid overload parity.

Shared encoders use bounded pooled batches and incremental MD5. Sequences are consumed once without materialization or per-element allocations. Vector/color hashing, file hashes, and import storage keys are unchanged.

**Compatibility:** plane/hull fingerprints intentionally change. Invalidate caches keyed by the old geometry fingerprints.

## Evidence

- 116 focused tests, including independent golden encodings, one-shot/reentrant sequences, bounded allocations, and concurrency; complete hashing line/branch coverage.
- Both full suites pass 548 tests with 2 existing skips.
- Oblique scalar plane: **3.509 → 2.521 µs**, approximately **712 → 328 B**.
- 65,536-plane array: **8.665 → 3.871 ms**, approximately **4.20 MB → 322 B**.

[Full measurements, controls, slower samples, initial allocation regression, and sources](https://gist.github.com/stefanmaierhofer/5358a7af2795d9f640ad10ca94f871f1)

Closes #95.

Implementation: 264ab572e7e2c5ec4a75a012fec4dc330c44cd1d
